### PR TITLE
Refactor (api/notion) : Database Query Type 업데이트 & 적용

### DIFF
--- a/app/api/database/article/route.ts
+++ b/app/api/database/article/route.ts
@@ -1,19 +1,33 @@
 import { NextRequest, NextResponse } from "next/server";
-import { baseQuery, notionDatabaseUrl, postHeaders } from "@/app/data/notion";
+import { DatabaseQueryParameters } from "@/app/types/notion";
+import { notionDatabaseUrl, postHeaders } from "@/app/data/notion";
 import { PageObjectResponse, QueryDatabaseResponse } from "@notionhq/client/build/src/api-endpoints";
 
 export const GET = async (req: NextRequest) => {
     const pageSize: string | null = req.nextUrl.searchParams.get("page_size");
+
+    const paramsQuery: DatabaseQueryParameters = {
+        filter: {
+            property: "Status",
+            status: {
+                equals: "Published",
+            },
+        },
+        sorts: [
+            {
+                property: "Date",
+                direction: "descending",
+            },
+        ],
+        page_size: pageSize ? parseInt(pageSize) : 9,
+    };
 
     try {
         const response = await fetch(`${notionDatabaseUrl}/query`, {
             method: "POST",
             headers: postHeaders,
             next: { revalidate: 0 },
-            body: JSON.stringify({
-                ...baseQuery,
-                page_size: pageSize ?? 9,
-            }),
+            body: JSON.stringify(paramsQuery),
         });
 
         if (!response.ok) throw new Error(response.statusText);
@@ -33,15 +47,25 @@ export const GET = async (req: NextRequest) => {
 export const POST = async (req: NextRequest) => {
     const { nextCursor }: { nextCursor: string | null } = await req.json();
 
-    const paramsQuery = {
-            filter: {
-                "and": [
-                    baseQuery.filter,
-                    updateParamsQuery(req.nextUrl.searchParams),
-                ],
+    const paramsQuery: DatabaseQueryParameters = {
+        filter: {
+            and: [
+                {
+                    property: "Status",
+                    status: {
+                        equals: "Published",
+                    },
+                },
+                updateParamsQuery(req.nextUrl.searchParams),
+            ],
+        },
+        sorts: [
+            {
+                property: "Date",
+                direction: "descending",
             },
-            sorts: baseQuery.sorts,
-            page_size: 9,
+        ],
+        page_size: 9,
     }
 
     try {
@@ -54,7 +78,7 @@ export const POST = async (req: NextRequest) => {
                 start_cursor: nextCursor,
             } : paramsQuery),
         });
-    
+
         if (!response.ok) throw new Error(response.statusText);
 
         const responseData: QueryDatabaseResponse = await response.json();

--- a/app/data/notion.ts
+++ b/app/data/notion.ts
@@ -1,5 +1,5 @@
-export const databaseId = process.env.NEXT_PUBLIC_NOTION_DATABASE_ID!;
-export const notionDatabaseUrl = `https://api.notion.com/v1/databases/${databaseId}`;
+export const notionDatabaseId = process.env.NEXT_PUBLIC_NOTION_DATABASE_ID!;
+export const notionDatabaseUrl = `https://api.notion.com/v1/databases/${notionDatabaseId}`;
 export const notionBlockUrl = "https://api.notion.com/v1/blocks";
 
 export const getHeaders = {
@@ -10,17 +10,4 @@ export const getHeaders = {
 export const postHeaders = {
     ...getHeaders,
     "Content-Type": "application/json",
-};
-
-export const baseQuery = {
-    filter: {
-        property: "Status",
-        status: {
-            equals: "Published",
-        },
-    },
-    sorts: [{
-        property: "Date",
-        direction: "descending",
-    }],
 };

--- a/app/types/notion.ts
+++ b/app/types/notion.ts
@@ -1,4 +1,4 @@
-import { BlockObjectResponse, PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
+import { BlockObjectResponse, PageObjectResponse, QueryDatabaseParameters } from "@notionhq/client/build/src/api-endpoints";
 
 export class ArticlesResponse {
     constructor(
@@ -59,3 +59,5 @@ export class BlocksResponse {
         this._nextCursor = cursor;
     }
 };
+
+export type DatabaseQueryParameters = Omit<QueryDatabaseParameters, "database_id">


### PR DESCRIPTION
- Notion SDK의 Query 타입에서 불필요한 Key 제거
  - 내용 : Typescript 유틸리티 타입 중 **_Omit_**을 사용하여 특정 Key를 생략한 타입 정의 (**`DatabaseQueryParameters`**)
- 새롭게 정의한 타입 → API 적용