### PR TITLE
[Feature] Add posts retrieval API with list and detail pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   lint:
-    name: Check lint
+    name: Lint validation
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || !github.event.pull_request.draft
     timeout-minutes: 5
@@ -31,7 +31,7 @@ jobs:
         run: pnpm lint
 
   types:
-    name: Check types
+    name: Type validation
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || !github.event.pull_request.draft
     timeout-minutes: 5
@@ -45,7 +45,7 @@ jobs:
       - name: Generate worker types
         run: pnpm gen
 
-      - name: Run check
+      - name: Check types
         run: pnpm check
 
       - name: Generate API types
@@ -67,7 +67,7 @@ jobs:
           fi
 
   test:
-    name: Test
+    name: Test validation
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || !github.event.pull_request.draft
     timeout-minutes: 5
@@ -85,7 +85,7 @@ jobs:
         run: pnpm test
 
   build:
-    name: Build
+    name: Build validation
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || !github.event.pull_request.draft
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-env
 
+      - name: Generate worker types
+        run: pnpm gen
+
       - name: Run check
         run: pnpm check
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -242,6 +242,7 @@ components:
         data:
           $ref: '#/components/schemas/Post'
         error:
+          enum: [null]
           nullable: true
 
     ApiSuccessResponsePostList:
@@ -260,6 +261,7 @@ components:
           items:
             $ref: '#/components/schemas/Post'
         error:
+          enum: [null]
           nullable: true
 
     ApiErrorResponse:
@@ -274,6 +276,7 @@ components:
           type: boolean
           enum: [false]
         data:
+          enum: [null]
           nullable: true
         error:
           $ref: '#/components/schemas/ApiError'

--- a/openapi.yml
+++ b/openapi.yml
@@ -6,6 +6,39 @@ info:
 
 paths:
   /api/posts:
+    get:
+      summary: List posts
+      operationId: listPosts
+      responses:
+        '200':
+          description: Posts retrieved successfully (sorted by newest first)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiSuccessResponsePostList'
+        '500':
+          description: Internal server error (bucket not found or unknown server error)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                bucketNotFound:
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      code: BUCKET_NOT_FOUND
+                      message: Blog bucket not found in environment variables
+                      details: null
+                serverError:
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      code: SERVER_ERROR
+                      message: Unknown error
+                      details: null
     post:
       summary: Create a post
       operationId: createPost
@@ -60,7 +93,76 @@ paths:
                     error:
                       code: SERVER_ERROR
                       message: Unknown error
-                      details: {}
+                      details: null
+
+  /api/posts/{id}:
+    get:
+      summary: Get post by id
+      operationId: getPostById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Post id
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Post retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiSuccessResponsePost'
+        '400':
+          description: Invalid request (missing id)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              example:
+                success: false
+                data: null
+                error:
+                  code: INVALID_REQUEST
+                  message: Post id is required
+                  details: null
+        '404':
+          description: Post not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              example:
+                success: false
+                data: null
+                error:
+                  code: POST_NOT_FOUND
+                  message: Post not found
+                  details:
+                    id: 4e9344a8-b642-47fb-8e8b-b0f1343f77df
+        '500':
+          description: Internal server error (bucket not found or unknown server error)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                bucketNotFound:
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      code: BUCKET_NOT_FOUND
+                      message: Blog bucket not found in environment variables
+                      details: null
+                serverError:
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      code: SERVER_ERROR
+                      message: Unknown error
+                      details: null
 
 components:
   schemas:
@@ -127,6 +229,24 @@ components:
           enum: [true]
         data:
           $ref: '#/components/schemas/Post'
+        error:
+          nullable: true
+
+    ApiSuccessResponsePostList:
+      type: object
+      additionalProperties: false
+      required:
+        - success
+        - data
+        - error
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Post'
         error:
           nullable: true
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -214,7 +214,19 @@ components:
         message:
           type: string
         details:
+          oneOf:
+            - $ref: '#/components/schemas/PostNotFoundErrorDetails'
           nullable: true
+
+    PostNotFoundErrorDetails:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          format: uuid
 
     ApiSuccessResponsePost:
       type: object

--- a/src/lib/components/editor/Editor.css
+++ b/src/lib/components/editor/Editor.css
@@ -2,6 +2,14 @@
   .milkdown-container {
     @apply size-full rounded-md px-4 py-3 ring ring-gray-300;
     @apply focus-within:ring-gray-700;
+
+    &:has([contenteditable='false']) {
+      @apply ring-0;
+
+      &.ProseMirror {
+        @apply cursor-default;
+      }
+    }
   }
 
   .milkdown-editor.prose {

--- a/src/lib/components/editor/Editor.svelte
+++ b/src/lib/components/editor/Editor.svelte
@@ -6,10 +6,12 @@
 
   type Props = HTMLAttributes<HTMLDivElement> & {
     content: string;
+    readOnly?: boolean;
   };
 
   let {
     content = $bindable(),
+    readOnly = false,
     class: className,
     ...divProps
   }: Props = $props();
@@ -17,6 +19,8 @@
   let editorElement: HTMLElement;
 
   function focusEditorOnContainerMouseDown(event: MouseEvent) {
+    if (readOnly) return;
+
     const target = event.target;
     const editable = editorElement.querySelector<HTMLElement>(
       '[contenteditable="true"]',
@@ -34,10 +38,14 @@
     await createMilkdownEditor({
       root: editorElement,
       defaultValue: content,
+      readOnly,
       onChange: (markdown: string) => {
         content = markdown;
       },
     });
+
+    if (readOnly) return;
+
     editorElement
       .querySelector('[contenteditable="true"]')
       ?.setAttribute('aria-label', 'content');

--- a/src/lib/components/editor/Editor.svelte.spec.ts
+++ b/src/lib/components/editor/Editor.svelte.spec.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Editor as MilkdownEditor } from '@milkdown/core';
+import { render } from 'vitest-browser-svelte';
+
+import Editor from './Editor.svelte';
+
+interface MilkdownEditorOptions {
+  root: HTMLElement;
+  defaultValue: string;
+  onChange?: (markdown: string) => void;
+  readOnly?: boolean;
+}
+
+const { createMilkdownEditorMock } = vi.hoisted(() => ({
+  createMilkdownEditorMock: vi.fn(
+    async ({ root }: MilkdownEditorOptions): Promise<MilkdownEditor> => {
+      const editable = document.createElement('div');
+      editable.setAttribute('contenteditable', 'true');
+      root.appendChild(editable);
+      return {} as MilkdownEditor;
+    },
+  ),
+}));
+
+vi.mock('./config', () => ({
+  createMilkdownEditor: createMilkdownEditorMock,
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('[Components] Editor', () => {
+  it('should create milkdown editor with initial content', async () => {
+    render(Editor, { content: 'hello world' });
+
+    await expect.poll(() => createMilkdownEditorMock.mock.calls.length).toBe(1);
+
+    const options = createMilkdownEditorMock.mock.calls[0][0];
+    expect(options.defaultValue).toBe('hello world');
+    expect(options.readOnly).toBe(false);
+    expect(options.root).toBeInstanceOf(HTMLElement);
+    expect(typeof options.onChange).toBe('function');
+  });
+
+  it('should set aria-label on editable element when not readonly', async () => {
+    render(Editor, { content: 'hello world' });
+
+    await expect
+      .poll(() => document.querySelector('[aria-label="content"]'))
+      .not.toBeNull();
+  });
+
+  it('should not set aria-label when readonly', async () => {
+    render(Editor, { content: 'hello world', readOnly: true });
+
+    await expect.poll(() => createMilkdownEditorMock.mock.calls.length).toBe(1);
+
+    expect(document.querySelector('[aria-label="content"]')).toBeNull();
+  });
+});

--- a/src/lib/components/editor/config.spec.ts
+++ b/src/lib/components/editor/config.spec.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Editor as MilkdownEditor } from '@milkdown/core';
+
+import { createMilkdownEditor } from './config';
+
+interface MockCtx {
+  set: (token: string, value: HTMLElement | string) => void;
+  update: (
+    token: string,
+    updater: (prev: { flag: boolean }) => {
+      flag: boolean;
+      editable: () => boolean;
+    },
+  ) => void;
+  get: (token: string) => {
+    markdownUpdated: (
+      callback: (ctx: string, markdown: string, prevMarkdown: string) => void,
+    ) => void;
+  } | null;
+}
+
+type ListenerCallback = (
+  ctx: string,
+  markdown: string,
+  prevMarkdown: string,
+) => void;
+
+const state = vi.hoisted(() => ({
+  listenerCallback: null as ListenerCallback | null,
+  setMock: vi.fn<(token: string, value: HTMLElement | string) => void>(),
+  updateMock: vi.fn<
+    (
+      token: string,
+      updater: (prev: { flag: boolean }) => {
+        flag: boolean;
+        editable: () => boolean;
+      },
+    ) => void
+  >(),
+  createMock: vi.fn(async (): Promise<MilkdownEditor> => {
+    return {} as MilkdownEditor;
+  }),
+}));
+
+vi.mock('@milkdown/core', () => ({
+  commandsCtx: 'commandsCtx',
+  defaultValueCtx: 'defaultValueCtx',
+  editorViewCtx: 'editorViewCtx',
+  editorViewOptionsCtx: 'editorViewOptionsCtx',
+  rootCtx: 'rootCtx',
+  Editor: {
+    make: () => {
+      const ctx: MockCtx = {
+        set: state.setMock,
+        update: state.updateMock,
+        get: (token: string) => {
+          if (token === 'listenerCtx') {
+            return {
+              markdownUpdated: (
+                callback: (
+                  ctx: string,
+                  markdown: string,
+                  prevMarkdown: string,
+                ) => void,
+              ) => {
+                void ctx;
+                state.listenerCallback = callback;
+              },
+            };
+          }
+
+          return null;
+        },
+      };
+
+      const builder = {
+        config: (fn: (nextCtx: MockCtx) => void) => {
+          fn(ctx);
+          return builder;
+        },
+        use: (plugin: object) => {
+          void plugin;
+          return builder;
+        },
+        create: state.createMock,
+      };
+
+      return builder;
+    },
+  },
+}));
+
+vi.mock('@milkdown/plugin-listener', () => ({
+  listener: { key: 'listener' },
+  listenerCtx: 'listenerCtx',
+}));
+
+vi.mock('@milkdown/preset-commonmark', () => {
+  const wrapInHeadingCommand = { key: 'wrapInHeadingCommand' };
+  const wrapInHeadingInputRule = { key: 'wrapInHeadingInputRule' };
+  const headingKeymap = { key: 'headingKeymap' };
+
+  return {
+    commonmark: [wrapInHeadingCommand, wrapInHeadingInputRule, headingKeymap],
+    downgradeHeadingCommand: { key: 'downgradeHeadingCommand' },
+    headingKeymap,
+    headingSchema: {
+      type: (ctx: object) => {
+        void ctx;
+        return {};
+      },
+    },
+    paragraphSchema: {
+      type: (ctx: object) => {
+        void ctx;
+        return {};
+      },
+    },
+    wrapInHeadingCommand,
+    wrapInHeadingInputRule,
+  };
+});
+
+vi.mock('@milkdown/prose/commands', () => ({
+  setBlockType: (type: object, attrs?: { level: number }) => {
+    void type;
+    void attrs;
+    return () => true;
+  },
+}));
+
+vi.mock('@milkdown/prose/inputrules', () => ({
+  textblockTypeInputRule: (
+    regexp: RegExp,
+    type: object,
+    attrs: (match: RegExpMatchArray & { groups?: { hashes?: string } }) => {
+      level: number;
+    },
+  ) => {
+    void regexp;
+    void type;
+    void attrs;
+    return { key: 'textblockTypeInputRule' };
+  },
+}));
+
+vi.mock('@milkdown/utils', () => ({
+  $command: (
+    key: string,
+    factory: (ctx: object) => (level?: number) => object,
+  ) => {
+    void factory;
+    return { key };
+  },
+  $inputRule: (factory: (ctx: object) => object) => {
+    void factory;
+    return { key: 'inputRule' };
+  },
+  $useKeymap: (
+    key: string,
+    keymap: Record<
+      string,
+      {
+        shortcuts: string | string[];
+        command: (ctx: {
+          get: (token: string) => {
+            call: (key: string, level?: number) => boolean;
+          };
+        }) => () => boolean;
+      }
+    >,
+  ) => {
+    void keymap;
+    return { key };
+  },
+}));
+
+function getListenerCallback(): ListenerCallback {
+  if (state.listenerCallback === null)
+    throw new Error('listener callback is required');
+
+  return state.listenerCallback as ListenerCallback;
+}
+
+describe('[Components] Editor config', () => {
+  it('should normalize heading levels before setting default value', async () => {
+    state.setMock.mockClear();
+
+    const root = {} as HTMLElement;
+    const markdown = '#### Heading\\n```\\n##### keep\\n```\\n###### Tail';
+
+    await createMilkdownEditor({ root, defaultValue: markdown });
+
+    expect(state.setMock).toHaveBeenCalledWith('rootCtx', root);
+    expect(state.setMock).toHaveBeenCalledWith(
+      'defaultValueCtx',
+      'Heading\\n```\\n##### keep\\n```\\n###### Tail',
+    );
+  });
+
+  it('should call onChange with normalized markdown only when changed', async () => {
+    state.listenerCallback = null;
+    const onChange = vi.fn<(markdown: string) => void>();
+
+    await createMilkdownEditor({
+      root: {} as HTMLElement,
+      defaultValue: '',
+      onChange,
+    });
+
+    const callback = getListenerCallback();
+
+    callback('ctx', '#### Same', 'Same');
+    expect(onChange).not.toHaveBeenCalled();
+
+    callback('ctx', '###### Next', 'Old');
+    expect(onChange).toHaveBeenCalledWith('Next');
+  });
+});

--- a/src/lib/components/editor/config.ts
+++ b/src/lib/components/editor/config.ts
@@ -3,6 +3,7 @@ import {
   defaultValueCtx,
   Editor,
   editorViewCtx,
+  editorViewOptionsCtx,
   rootCtx,
 } from '@milkdown/core';
 import type { MilkdownPlugin } from '@milkdown/ctx';
@@ -23,7 +24,8 @@ import { $command, $inputRule, $useKeymap } from '@milkdown/utils';
 interface EditorOptions {
   root: HTMLElement;
   defaultValue: string;
-  onChange: (markdown: string) => void;
+  onChange?: (markdown: string) => void;
+  readOnly?: boolean;
 }
 
 function normalizeHeadingLevels(markdown: string): string {
@@ -127,11 +129,19 @@ export const createMilkdownEditor = async ({
   root,
   defaultValue,
   onChange,
+  readOnly = false,
 }: EditorOptions): Promise<Editor> => {
   return await Editor.make()
     .config(ctx => {
       ctx.set(rootCtx, root);
       ctx.set(defaultValueCtx, normalizeHeadingLevels(defaultValue));
+      ctx.update(editorViewOptionsCtx, prev => ({
+        ...prev,
+        editable: () => !readOnly,
+      }));
+
+      if (!onChange || readOnly) return;
+
       ctx.get(listenerCtx).markdownUpdated((_, markdown, prevMarkdown) => {
         const next = normalizeHeadingLevels(markdown);
         const prev = normalizeHeadingLevels(prevMarkdown);

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -1,16 +1,12 @@
-import type { components } from '$lib/types/schema';
+import type { components, operations } from '$lib/types/schema';
 
 type SchemaApiError = components['schemas']['ApiError'];
 type SchemaApiErrorResponse = components['schemas']['ApiErrorResponse'];
-type SchemaApiSuccessResponsePost =
-  components['schemas']['ApiSuccessResponsePost'];
 
 export type ApiError = SchemaApiError;
 
-export type ApiSuccessResponse<T> = Omit<
-  SchemaApiSuccessResponsePost,
-  'data' | 'error'
-> & {
+export type ApiSuccessResponse<T> = {
+  success: true;
   data: T;
   error: null;
   message?: string;
@@ -22,3 +18,13 @@ export type ApiErrorResponse = Omit<SchemaApiErrorResponse, 'data'> & {
 };
 
 export type ApiResponse<T> = ApiSuccessResponse<T> | ApiErrorResponse;
+
+type SchemaPost = components['schemas']['Post'];
+
+export type ListPostsApiResponse = ApiResponse<SchemaPost[]>;
+export type CreatePostApiResponse = ApiResponse<SchemaPost>;
+export type GetPostByIdApiResponse = ApiResponse<SchemaPost>;
+
+export type ListPostsOperation = operations['listPosts'];
+export type CreatePostOperation = operations['createPost'];
+export type GetPostByIdOperation = operations['getPostById'];

--- a/src/lib/types/post.ts
+++ b/src/lib/types/post.ts
@@ -1,10 +1,5 @@
-export interface Post {
-  id: ReturnType<typeof crypto.randomUUID>;
-  title: string;
-  content: string;
-  createdAt: string;
-  updatedAt: string;
-}
+import type { components } from '$lib/types/schema';
 
-export type CreatePostInput = Pick<Post, 'title' | 'content'>;
-export type UpdatePostInput = Omit<Post, 'id' | 'createdAt'>;
+export type Post = components['schemas']['Post'];
+export type CreatePostInput = components['schemas']['CreatePostInput'];
+export type UpdatePostInput = Pick<Post, 'title' | 'content' | 'updatedAt'>;

--- a/src/lib/types/schema.d.ts
+++ b/src/lib/types/schema.d.ts
@@ -60,7 +60,11 @@ export interface components {
     ApiError: {
       code: string;
       message: string;
-      details: unknown;
+      details: components['schemas']['PostNotFoundErrorDetails'] | null;
+    };
+    PostNotFoundErrorDetails: {
+      /** Format: uuid */
+      id: string;
     };
     ApiSuccessResponsePost: {
       /** @enum {boolean} */

--- a/src/lib/types/schema.d.ts
+++ b/src/lib/types/schema.d.ts
@@ -11,10 +11,28 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get?: never;
+    /** List posts */
+    get: operations['listPosts'];
     put?: never;
     /** Create a post */
     post: operations['createPost'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/posts/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get post by id */
+    get: operations['getPostById'];
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -50,6 +68,12 @@ export interface components {
       data: components['schemas']['Post'];
       error: unknown;
     };
+    ApiSuccessResponsePostList: {
+      /** @enum {boolean} */
+      success: true;
+      data: components['schemas']['Post'][];
+      error: unknown;
+    };
     ApiErrorResponse: {
       /** @enum {boolean} */
       success: false;
@@ -65,6 +89,35 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  listPosts: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Posts retrieved successfully (sorted by newest first) */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ApiSuccessResponsePostList'];
+        };
+      };
+      /** @description Internal server error (bucket not found or unknown server error) */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ApiErrorResponse'];
+        };
+      };
+    };
+  };
   createPost: {
     parameters: {
       query?: never;
@@ -107,6 +160,80 @@ export interface operations {
            *         "code": "INVALID_REQUEST",
            *         "message": "Request body must be a valid JSON object",
            *         "details": null
+           *       }
+           *     }
+           */
+          'application/json': components['schemas']['ApiErrorResponse'];
+        };
+      };
+      /** @description Internal server error (bucket not found or unknown server error) */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ApiErrorResponse'];
+        };
+      };
+    };
+  };
+  getPostById: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Post id */
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Post retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ApiSuccessResponsePost'];
+        };
+      };
+      /** @description Invalid request (missing id) */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example {
+           *       "success": false,
+           *       "data": null,
+           *       "error": {
+           *         "code": "INVALID_REQUEST",
+           *         "message": "Post id is required",
+           *         "details": null
+           *       }
+           *     }
+           */
+          'application/json': components['schemas']['ApiErrorResponse'];
+        };
+      };
+      /** @description Post not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example {
+           *       "success": false,
+           *       "data": null,
+           *       "error": {
+           *         "code": "POST_NOT_FOUND",
+           *         "message": "Post not found",
+           *         "details": {
+           *           "id": "4e9344a8-b642-47fb-8e8b-b0f1343f77df"
+           *         }
            *       }
            *     }
            */

--- a/src/lib/types/schema.d.ts
+++ b/src/lib/types/schema.d.ts
@@ -70,18 +70,21 @@ export interface components {
       /** @enum {boolean} */
       success: true;
       data: components['schemas']['Post'];
-      error: unknown;
+      /** @enum {unknown|null} */
+      error: null;
     };
     ApiSuccessResponsePostList: {
       /** @enum {boolean} */
       success: true;
       data: components['schemas']['Post'][];
-      error: unknown;
+      /** @enum {unknown|null} */
+      error: null;
     };
     ApiErrorResponse: {
       /** @enum {boolean} */
       success: false;
-      data: unknown;
+      /** @enum {unknown|null} */
+      data: null;
       error: components['schemas']['ApiError'];
     };
   };

--- a/src/routes/admin/posts/+page.server.ts
+++ b/src/routes/admin/posts/+page.server.ts
@@ -1,11 +1,11 @@
-import type { ApiResponse } from '$lib/types/api';
+import type { ListPostsApiResponse } from '$lib/types/api';
 import type { Post } from '$lib/types/post';
 
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ fetch }) => {
   const res = await fetch('/api/posts');
-  const response: ApiResponse<Post[]> = await res.json();
+  const response: ListPostsApiResponse = await res.json();
 
   if (!response.success)
     return { posts: [] as Post[], loadError: response.error.message };

--- a/src/routes/admin/posts/+page.server.ts
+++ b/src/routes/admin/posts/+page.server.ts
@@ -1,0 +1,14 @@
+import type { ApiResponse } from '$lib/types/api';
+import type { Post } from '$lib/types/post';
+
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ fetch }) => {
+  const res = await fetch('/api/posts');
+  const response: ApiResponse<Post[]> = await res.json();
+
+  if (!response.success)
+    return { posts: [] as Post[], loadError: response.error.message };
+
+  return { posts: response.data };
+};

--- a/src/routes/admin/posts/+page.svelte
+++ b/src/routes/admin/posts/+page.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  function formatDate(iso: string) {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+</script>
+
+<svelte:head>
+  <title>Posts — Admin</title>
+</svelte:head>
+
+<div class="mx-auto max-w-5xl px-4 py-12">
+  <div class="mb-8 flex items-center justify-between">
+    <h1 class="text-2xl font-bold text-gray-900">Posts</h1>
+    <a
+      href={resolve('/admin/posts/new')}
+      class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+    >
+      New post
+    </a>
+  </div>
+
+  {#if data.loadError}
+    <div class="rounded-md border border-red-200 bg-red-50 p-4">
+      <p class="text-sm text-red-700">{data.loadError}</p>
+    </div>
+  {:else if data.posts.length === 0}
+    <div
+      class="rounded-lg border-2 border-dashed border-gray-200 py-16 text-center"
+    >
+      <p class="text-gray-400">No posts yet.</p>
+      <a
+        href={resolve('/admin/posts/new')}
+        class="mt-3 inline-block text-sm font-medium text-blue-600 hover:underline"
+      >
+        Write the first post →
+      </a>
+    </div>
+  {:else}
+    <div class="overflow-hidden rounded-lg border border-gray-200 shadow-sm">
+      <table class="w-full text-sm">
+        <thead class="bg-gray-50 text-left">
+          <tr>
+            <th class="px-4 py-3 font-medium text-gray-500">Title</th>
+            <th class="hidden px-4 py-3 font-medium text-gray-500 md:table-cell"
+              >Created</th
+            >
+            <th class="hidden px-4 py-3 font-medium text-gray-500 lg:table-cell"
+              >Updated</th
+            >
+            <th class="px-4 py-3 text-right font-medium text-gray-500"
+              >Actions</th
+            >
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100 bg-white">
+          {#each data.posts as post (post.id)}
+            <tr class="hover:bg-gray-50">
+              <td class="px-4 py-3">
+                <a href={resolve(`/posts/${post.id}`)} class="group">
+                  <strong
+                    class="font-medium text-gray-900 group-hover:text-blue-600 group-hover:underline"
+                  >
+                    {post.title}
+                  </strong>
+                  <p class="mt-0.5 font-mono text-xs text-gray-400">
+                    {post.id}
+                  </p>
+                </a>
+              </td>
+              <td class="hidden px-4 py-3 text-gray-500 md:table-cell">
+                {formatDate(post.createdAt)}
+              </td>
+              <td class="hidden px-4 py-3 text-gray-500 lg:table-cell">
+                {formatDate(post.updatedAt)}
+              </td>
+              <td class="px-4 py-3 text-right">
+                <div class="flex items-center justify-end gap-4">
+                  <a
+                    href={resolve(`/posts/${post.id}`)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-gray-500 hover:text-blue-600"
+                  >
+                    View ↗
+                  </a>
+                </div>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+    <p class="mt-3 text-right text-xs text-gray-400">
+      {data.posts.length} post{data.posts.length !== 1 ? 's' : ''}
+    </p>
+  {/if}
+</div>

--- a/src/routes/admin/posts/new/+page.svelte
+++ b/src/routes/admin/posts/new/+page.svelte
@@ -4,8 +4,8 @@
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { Editor } from '$lib/components/editor';
-  import type { ApiResponse } from '$lib/types/api';
-  import type { CreatePostInput, Post } from '$lib/types/post';
+  import type { CreatePostApiResponse } from '$lib/types/api';
+  import type { CreatePostInput } from '$lib/types/post';
 
   const STORAGE_KEY = 'DRAFT_POST';
 
@@ -46,7 +46,7 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(postData),
       });
-      const apiResponse: ApiResponse<Post> = await res.json();
+      const apiResponse: CreatePostApiResponse = await res.json();
 
       if (apiResponse.success) {
         clearData();

--- a/src/routes/admin/posts/new/+page.svelte
+++ b/src/routes/admin/posts/new/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount } from 'svelte';
 
+  import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { Editor } from '$lib/components/editor';
   import type { ApiResponse } from '$lib/types/api';
   import type { CreatePostInput, Post } from '$lib/types/post';
@@ -22,10 +24,6 @@
     postData.title.trim().length > 0 || postData.content.trim().length > 0,
   );
 
-  let result = $state<
-    { type: 'success'; data: Post } | { type: 'error'; message: string } | null
-  >(null);
-
   function clearData() {
     postData = {
       title: '',
@@ -41,7 +39,6 @@
   async function handleSubmit(e: SubmitEvent) {
     e.preventDefault();
     isSubmitting = true;
-    result = null;
 
     try {
       const res = await fetch('/api/posts', {
@@ -51,24 +48,12 @@
       });
       const apiResponse: ApiResponse<Post> = await res.json();
 
-      result = apiResponse.success
-        ? { type: 'success', ...apiResponse }
-        : {
-            type: 'error',
-            ...apiResponse.error,
-          };
-
       if (apiResponse.success) {
         clearData();
+        localStorage.removeItem(STORAGE_KEY);
+
+        await goto(resolve(`/posts/${apiResponse.data.id}`));
       }
-    } catch (error) {
-      result = {
-        type: 'error',
-        message:
-          error instanceof Error
-            ? error.message
-            : 'Unknown error occurred while submitting the post.',
-      };
     } finally {
       isSubmitting = false;
     }
@@ -98,22 +83,6 @@
 
 <div class="mx-auto flex h-full min-h-screen max-w-5xl flex-col px-4 py-12">
   <h1 class="mb-8 text-2xl font-bold text-gray-900">New post</h1>
-
-  {#if result}
-    {#if result.type === 'success'}
-      <div class="mb-6 rounded-md border border-green-200 bg-green-50 p-4">
-        <p class="text-sm font-medium text-green-800">
-          Created a new post successfully!
-        </p>
-        <p class="mt-1 text-xs text-green-600">ID: {result.data.id}</p>
-      </div>
-    {:else}
-      <div class="mb-6 rounded-md border border-red-200 bg-red-50 p-4">
-        <p class="text-sm font-medium text-red-800">{result.message}</p>
-      </div>
-    {/if}
-  {/if}
-
   <form onsubmit={handleSubmit} class="flex min-h-0 flex-1 flex-col gap-y-4">
     <div
       class="flex justify-end gap-x-2 **:[button]:rounded-md **:[button]:px-4 **:[button]:py-2 **:[button]:text-sm **:[button]:font-medium"
@@ -134,7 +103,6 @@
         {isSubmitting ? 'Submitting...' : 'Submit'}
       </button>
     </div>
-
     <div class="space-y-2">
       <label for="title" class="block text-sm font-medium">Title</label>
       <input

--- a/src/routes/admin/posts/new/page.svelte.spec.ts
+++ b/src/routes/admin/posts/new/page.svelte.spec.ts
@@ -7,9 +7,17 @@ import { page } from 'vitest/browser';
 
 import Page from './+page.svelte';
 
+const { gotoMock } = vi.hoisted(() => ({
+  gotoMock: vi.fn(),
+}));
+
+vi.mock('$app/navigation', () => ({
+  goto: gotoMock,
+}));
+
 const now = new Date().toISOString();
 const mockPost: Post = {
-  id: crypto.randomUUID(),
+  id: '123e4567-e89b-12d3-a456-426614174100',
   title: 'Test Title',
   content: 'Test Content',
   createdAt: now,
@@ -27,7 +35,6 @@ function stubFetch(response: ApiResponse<Post>): void {
 
 async function submitForm(): Promise<void> {
   await page.getByRole('textbox', { name: 'Title' }).fill('Hello');
-  await page.getByRole('textbox', { name: 'Content' }).fill('World');
   await page.getByRole('button', { name: 'Submit' }).click();
 }
 
@@ -35,6 +42,7 @@ describe('[Routes] /admin/posts/new', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     localStorage.clear();
+    gotoMock.mockReset();
   });
 
   it('should render form elements', async () => {
@@ -45,6 +53,9 @@ describe('[Routes] /admin/posts/new', () => {
       .toBeInTheDocument();
     await expect
       .element(page.getByRole('textbox', { name: 'Content' }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole('button', { name: 'Save draft' }))
       .toBeInTheDocument();
     await expect
       .element(page.getByRole('button', { name: 'Submit' }))
@@ -65,35 +76,45 @@ describe('[Routes] /admin/posts/new', () => {
       .element(page.getByRole('textbox', { name: 'Title' }))
       .toHaveValue('Draft Title');
     await expect
-      .element(page.getByRole('textbox', { name: 'Content' }))
+      .element(page.getByRole('textbox', { name: /content/i }))
       .toHaveTextContent('Draft Content');
   });
 
-  it('should show success message and reset form on successful submission', async () => {
+  it('should save draft to localStorage', async () => {
+    render(Page);
+
+    await page.getByRole('textbox', { name: 'Title' }).fill('Hello');
+    await page.getByRole('button', { name: 'Save draft' }).click();
+
+    expect(localStorage.getItem('DRAFT_POST')).toBe(
+      JSON.stringify({ title: 'Hello', content: '' }),
+    );
+  });
+
+  it('should navigate to post detail on successful submission', async () => {
     stubFetch({
       success: true,
       data: mockPost,
       error: null,
     });
+    localStorage.setItem(
+      'DRAFT_POST',
+      JSON.stringify({ title: 'A', content: 'B' }),
+    );
     render(Page);
 
     await submitForm();
 
-    await expect
-      .element(page.getByText('Created a new post successfully!'))
-      .toBeInTheDocument();
-    await expect
-      .element(page.getByText(`ID: ${mockPost.id}`))
-      .toBeInTheDocument();
-    await expect
-      .element(page.getByRole('textbox', { name: 'Title' }))
-      .toHaveValue('');
-    await expect
-      .element(page.getByRole('textbox', { name: 'Content' }))
-      .toBeInTheDocument();
+    expect(gotoMock).toHaveBeenCalledWith(`/posts/${mockPost.id}`);
+    expect(localStorage.getItem('DRAFT_POST')).toBeNull();
   });
 
-  it('should show error message on API error response', async () => {
+  it('should not navigate on API error response', async () => {
+    localStorage.setItem(
+      'DRAFT_POST',
+      JSON.stringify({ title: 'Draft Title', content: 'Draft Content' }),
+    );
+
     stubFetch({
       success: false,
       data: null,
@@ -107,20 +128,6 @@ describe('[Routes] /admin/posts/new', () => {
 
     await submitForm();
 
-    await expect
-      .element(page.getByText('Invalid input data.'))
-      .toBeInTheDocument();
-  });
-
-  it('should show error message on network failure', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockRejectedValueOnce(new Error('Network Error')),
-    );
-    render(Page);
-
-    await submitForm();
-
-    await expect.element(page.getByText('Network Error')).toBeInTheDocument();
+    expect(gotoMock).not.toHaveBeenCalled();
   });
 });

--- a/src/routes/admin/posts/new/page.svelte.spec.ts
+++ b/src/routes/admin/posts/new/page.svelte.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { ApiResponse } from '$lib/types/api';
+import type { CreatePostApiResponse } from '$lib/types/api';
 import type { Post } from '$lib/types/post';
 import { render } from 'vitest-browser-svelte';
 import { page } from 'vitest/browser';
@@ -24,7 +24,7 @@ const mockPost: Post = {
   updatedAt: now,
 };
 
-function stubFetch(response: ApiResponse<Post>): void {
+function stubFetch(response: CreatePostApiResponse): void {
   vi.stubGlobal(
     'fetch',
     vi

--- a/src/routes/admin/posts/page.server.spec.ts
+++ b/src/routes/admin/posts/page.server.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApiResponse } from '$lib/types/api';
+import type { Post } from '$lib/types/post';
+
+import type { PageServerLoadEvent } from './$types';
+import { load } from './+page.server';
+
+const mockPost: Post = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  title: 'Hello World',
+  content: 'Some content',
+  createdAt: '2026-01-15T00:00:00.000Z',
+  updatedAt: '2026-02-20T00:00:00.000Z',
+};
+
+function createMockFetch(response: ApiResponse<Post[]>) {
+  return vi.fn<PageServerLoadEvent['fetch']>(
+    async () =>
+      new Response(JSON.stringify(response), {
+        headers: { 'content-type': 'application/json' },
+      }),
+  );
+}
+
+function createLoadEvent(
+  fetch: PageServerLoadEvent['fetch'],
+): PageServerLoadEvent {
+  return {
+    cookies: {} as PageServerLoadEvent['cookies'],
+    fetch,
+    getClientAddress: () => '127.0.0.1',
+    locals: {} as PageServerLoadEvent['locals'],
+    params: {} as PageServerLoadEvent['params'],
+    platform: undefined,
+    request: new Request('http://localhost/admin/posts'),
+    route: { id: '/admin/posts' },
+    setHeaders: vi.fn(),
+    url: new URL('http://localhost/admin/posts'),
+    isDataRequest: false,
+    isSubRequest: false,
+    isRemoteRequest: false,
+    parent: async () => ({}),
+    depends: vi.fn(),
+    untrack: <T>(fn: () => T) => fn(),
+    tracing: {
+      enabled: false,
+      root: {} as PageServerLoadEvent['tracing']['root'],
+      current: {} as PageServerLoadEvent['tracing']['current'],
+    },
+  };
+}
+
+async function runLoad(fetch: PageServerLoadEvent['fetch']) {
+  const result = await load(createLoadEvent(fetch));
+  if (!result) throw new Error('Expected load to return data');
+  return result;
+}
+
+describe('[Routes] /admin/posts - load', () => {
+  it('should fetch from /api/posts', async () => {
+    const mockFetch = createMockFetch({
+      success: true,
+      data: [mockPost],
+      error: null,
+    });
+
+    await runLoad(mockFetch);
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/posts');
+  });
+
+  it('should return posts on successful response', async () => {
+    const mockFetch = createMockFetch({
+      success: true,
+      data: [mockPost],
+      error: null,
+    });
+
+    const result = await runLoad(mockFetch);
+
+    expect(result.posts).toEqual([mockPost]);
+  });
+
+  it('should return empty posts array on successful response with no posts', async () => {
+    const mockFetch = createMockFetch({ success: true, data: [], error: null });
+
+    const result = await runLoad(mockFetch);
+
+    expect(result.posts).toEqual([]);
+  });
+
+  it('should not include loadError on successful response', async () => {
+    const mockFetch = createMockFetch({
+      success: true,
+      data: [mockPost],
+      error: null,
+    });
+
+    const result = await runLoad(mockFetch);
+
+    expect(result.loadError).toBeUndefined();
+  });
+
+  it('should return empty posts on API error response', async () => {
+    const mockFetch = createMockFetch({
+      success: false,
+      data: null,
+      error: { code: 'INTERNAL_SERVER_ERROR', message: 'Something went wrong' },
+    } as ApiResponse<Post[]>);
+
+    const result = await runLoad(mockFetch);
+
+    expect(result.posts).toEqual([]);
+  });
+
+  it('should return loadError with error message on API error response', async () => {
+    const errorMessage = 'Failed to load posts';
+    const mockFetch = createMockFetch({
+      success: false,
+      data: null,
+      error: { code: 'INTERNAL_SERVER_ERROR', message: errorMessage },
+    } as ApiResponse<Post[]>);
+
+    const result = await runLoad(mockFetch);
+
+    expect(result.loadError).toBe(errorMessage);
+  });
+});

--- a/src/routes/admin/posts/page.server.spec.ts
+++ b/src/routes/admin/posts/page.server.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ApiResponse } from '$lib/types/api';
+import type { ListPostsApiResponse } from '$lib/types/api';
 import type { Post } from '$lib/types/post';
 
 import type { PageServerLoadEvent } from './$types';
@@ -14,7 +14,7 @@ const mockPost: Post = {
   updatedAt: '2026-02-20T00:00:00.000Z',
 };
 
-function createMockFetch(response: ApiResponse<Post[]>) {
+function createMockFetch(response: ListPostsApiResponse) {
   return vi.fn<PageServerLoadEvent['fetch']>(
     async () =>
       new Response(JSON.stringify(response), {
@@ -106,8 +106,12 @@ describe('[Routes] /admin/posts - load', () => {
     const mockFetch = createMockFetch({
       success: false,
       data: null,
-      error: { code: 'INTERNAL_SERVER_ERROR', message: 'Something went wrong' },
-    } as ApiResponse<Post[]>);
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Something went wrong',
+        details: null,
+      },
+    });
 
     const result = await runLoad(mockFetch);
 
@@ -119,8 +123,12 @@ describe('[Routes] /admin/posts - load', () => {
     const mockFetch = createMockFetch({
       success: false,
       data: null,
-      error: { code: 'INTERNAL_SERVER_ERROR', message: errorMessage },
-    } as ApiResponse<Post[]>);
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: errorMessage,
+        details: null,
+      },
+    });
 
     const result = await runLoad(mockFetch);
 

--- a/src/routes/admin/posts/page.svelte.spec.ts
+++ b/src/routes/admin/posts/page.svelte.spec.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Post } from '$lib/types/post';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+import Page from './+page.svelte';
+
+const mockPost: Post = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  title: 'Hello World',
+  content: 'Some content',
+  createdAt: '2026-01-15T00:00:00.000Z',
+  updatedAt: '2026-02-20T00:00:00.000Z',
+};
+
+const mockPost2: Post = {
+  id: '123e4567-e89b-12d3-a456-426614174001',
+  title: 'Second Post',
+  content: 'More content',
+  createdAt: '2026-03-01T00:00:00.000Z',
+  updatedAt: '2026-03-02T00:00:00.000Z',
+};
+
+describe('[Routes] /admin/posts', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('header', () => {
+    it('should render page heading', async () => {
+      render(Page, { data: { posts: [] } });
+
+      await expect
+        .element(page.getByRole('heading', { level: 1 }))
+        .toHaveTextContent('Posts');
+    });
+
+    it('should render "New post" link', async () => {
+      render(Page, { data: { posts: [] } });
+
+      await expect
+        .element(page.getByRole('link', { name: 'New post' }))
+        .toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('should display error message when loadError is present', async () => {
+      render(Page, { data: { posts: [], loadError: 'Failed to load posts' } });
+
+      await expect
+        .element(page.getByText('Failed to load posts'))
+        .toBeInTheDocument();
+    });
+
+    it('should not render posts table when loadError is present', async () => {
+      render(Page, { data: { posts: [], loadError: 'Failed to load posts' } });
+
+      await expect.element(page.getByRole('table')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', () => {
+    it('should display empty state message when no posts exist', async () => {
+      render(Page, { data: { posts: [] } });
+
+      await expect.element(page.getByText('No posts yet.')).toBeInTheDocument();
+    });
+
+    it('should display "Write the first post" link in empty state', async () => {
+      render(Page, { data: { posts: [] } });
+
+      await expect
+        .element(page.getByRole('link', { name: /Write the first post/ }))
+        .toBeInTheDocument();
+    });
+
+    it('should not render posts table when posts array is empty', async () => {
+      render(Page, { data: { posts: [] } });
+
+      await expect.element(page.getByRole('table')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('posts table', () => {
+    it('should render table when posts exist', async () => {
+      render(Page, { data: { posts: [mockPost] } });
+
+      await expect.element(page.getByRole('table')).toBeInTheDocument();
+    });
+
+    it('should display post title', async () => {
+      render(Page, { data: { posts: [mockPost] } });
+
+      await expect.element(page.getByText(mockPost.title)).toBeInTheDocument();
+    });
+
+    it('should display post id', async () => {
+      render(Page, { data: { posts: [mockPost] } });
+
+      await expect.element(page.getByText(mockPost.id)).toBeInTheDocument();
+    });
+
+    it('should render all posts', async () => {
+      render(Page, { data: { posts: [mockPost, mockPost2] } });
+
+      await expect.element(page.getByText(mockPost.title)).toBeInTheDocument();
+      await expect.element(page.getByText(mockPost2.title)).toBeInTheDocument();
+    });
+
+    it('should render a "View" link for the post', async () => {
+      render(Page, { data: { posts: [mockPost] } });
+
+      await expect
+        .element(page.getByRole('link', { name: 'View ↗' }))
+        .toBeInTheDocument();
+    });
+
+    it('should not show empty state when posts exist', async () => {
+      render(Page, { data: { posts: [mockPost] } });
+
+      await expect
+        .element(page.getByText('No posts yet.'))
+        .not.toBeInTheDocument();
+    });
+  });
+
+  describe('post count', () => {
+    it('should show singular "post" for one post', async () => {
+      render(Page, { data: { posts: [mockPost] } });
+
+      await expect.element(page.getByText('1 post')).toBeInTheDocument();
+    });
+
+    it('should show plural "posts" for multiple posts', async () => {
+      render(Page, { data: { posts: [mockPost, mockPost2] } });
+
+      await expect.element(page.getByText('2 posts')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/routes/api/posts/+server.ts
+++ b/src/routes/api/posts/+server.ts
@@ -18,6 +18,70 @@ function isPostRequestBody(body: unknown): body is CreatePostInput {
   );
 }
 
+export const GET: RequestHandler = async ({ platform }): Promise<Response> => {
+  try {
+    const bucket = platform?.env.BLOG;
+    if (!bucket) {
+      const error: ApiError = {
+        code: 'BUCKET_NOT_FOUND',
+        message: 'Blog bucket not found in environment variables',
+        details: null,
+      };
+
+      return json(
+        { success: false, data: null, error } satisfies ApiErrorResponse,
+        {
+          status: 500,
+          statusText: 'Internal Server Error',
+        },
+      );
+    }
+
+    const posts: Post[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const listedObjects = await bucket.list({ cursor });
+
+      for (const object of listedObjects.objects) {
+        const storedPost = await bucket.get(object.key);
+        if (!storedPost) {
+          continue;
+        }
+
+        posts.push(await storedPost.json<Post>());
+      }
+
+      cursor = listedObjects.truncated ? listedObjects.cursor : undefined;
+    } while (cursor);
+
+    posts.sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+
+    return json({
+      success: true,
+      data: posts,
+      error: null,
+    } satisfies ApiSuccessResponse<Post[]>);
+  } catch (e) {
+    const error: ApiError = {
+      code: 'SERVER_ERROR',
+      message: e instanceof Error ? e.message : 'Unknown error',
+      details: null,
+    };
+
+    return json(
+      { success: false, data: null, error } satisfies ApiErrorResponse,
+      {
+        status: 500,
+        statusText: 'Internal Server Error',
+      },
+    );
+  }
+};
+
 export const POST: RequestHandler = async ({
   platform,
   request,

--- a/src/routes/api/posts/+server.ts
+++ b/src/routes/api/posts/+server.ts
@@ -43,13 +43,15 @@ export const GET: RequestHandler = async ({ platform }): Promise<Response> => {
     do {
       const listedObjects = await bucket.list({ cursor });
 
-      const objectPromises = listedObjects.objects.map(async object => {
-        const storedPost = await bucket.get(object.key);
-        if (!storedPost) {
-          return null;
-        }
-        return storedPost.json<Post>();
-      });
+      const objectPromises = listedObjects.objects.map(
+        async (object: { key: string }) => {
+          const storedPost = await bucket.get(object.key);
+          if (!storedPost) {
+            return null;
+          }
+          return storedPost.json<Post>();
+        },
+      );
       const pagePosts = await Promise.all(objectPromises);
 
       for (const post of pagePosts) {

--- a/src/routes/api/posts/+server.ts
+++ b/src/routes/api/posts/+server.ts
@@ -43,13 +43,17 @@ export const GET: RequestHandler = async ({ platform }): Promise<Response> => {
     do {
       const listedObjects = await bucket.list({ cursor });
 
-      for (const object of listedObjects.objects) {
+      const objectPromises = listedObjects.objects.map(async object => {
         const storedPost = await bucket.get(object.key);
         if (!storedPost) {
-          continue;
+          return null;
         }
+        return storedPost.json<Post>();
+      });
+      const pagePosts = await Promise.all(objectPromises);
 
-        posts.push(await storedPost.json<Post>());
+      for (const post of pagePosts) {
+        if (post) posts.push(post);
       }
 
       cursor = listedObjects.truncated ? listedObjects.cursor : undefined;

--- a/src/routes/api/posts/[id]/+server.ts
+++ b/src/routes/api/posts/[id]/+server.ts
@@ -1,0 +1,88 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+import type {
+  ApiError,
+  ApiErrorResponse,
+  ApiSuccessResponse,
+} from '$lib/types/api';
+import type { Post } from '$lib/types/post';
+
+export const GET: RequestHandler = async ({
+  platform,
+  params,
+}): Promise<Response> => {
+  try {
+    const postId = params.id;
+    if (!postId) {
+      const error: ApiError = {
+        code: 'INVALID_REQUEST',
+        message: 'Post id is required',
+        details: null,
+      };
+
+      return json(
+        { success: false, data: null, error } satisfies ApiErrorResponse,
+        {
+          status: 400,
+          statusText: 'Bad Request',
+        },
+      );
+    }
+
+    const bucket = platform?.env.BLOG;
+    if (!bucket) {
+      const error: ApiError = {
+        code: 'BUCKET_NOT_FOUND',
+        message: 'Blog bucket not found in environment variables',
+        details: null,
+      };
+
+      return json(
+        { success: false, data: null, error } satisfies ApiErrorResponse,
+        {
+          status: 500,
+          statusText: 'Internal Server Error',
+        },
+      );
+    }
+
+    const storedPost = await bucket.get(postId);
+    if (!storedPost) {
+      const error: ApiError = {
+        code: 'POST_NOT_FOUND',
+        message: 'Post not found',
+        details: { id: postId },
+      };
+
+      return json(
+        { success: false, data: null, error } satisfies ApiErrorResponse,
+        {
+          status: 404,
+          statusText: 'Not Found',
+        },
+      );
+    }
+
+    const post = await storedPost.json<Post>();
+
+    return json({
+      success: true,
+      data: post,
+      error: null,
+    } satisfies ApiSuccessResponse<Post>);
+  } catch (e) {
+    const error: ApiError = {
+      code: 'SERVER_ERROR',
+      message: e instanceof Error ? e.message : 'Unknown error',
+      details: null,
+    };
+
+    return json(
+      { success: false, data: null, error } satisfies ApiErrorResponse,
+      {
+        status: 500,
+        statusText: 'Internal Server Error',
+      },
+    );
+  }
+};

--- a/src/routes/api/posts/[id]/server.spec.ts
+++ b/src/routes/api/posts/[id]/server.spec.ts
@@ -2,7 +2,7 @@ import type { RequestEvent } from '@sveltejs/kit';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ApiResponse } from '$lib/types/api';
+import type { GetPostByIdApiResponse } from '$lib/types/api';
 import type { Post } from '$lib/types/post';
 
 import { GET } from './+server';
@@ -64,7 +64,7 @@ describe('GET /api/posts/[id]', () => {
     const platform = createMockPlatform();
     const event = createMockEvent({ request, platform, postId: '' });
     const response = await GET(event);
-    const result: ApiResponse<null> = await response.json();
+    const result: GetPostByIdApiResponse = await response.json();
 
     expect(response.status).toBe(400);
     expect(result.success).toBe(false);
@@ -78,7 +78,7 @@ describe('GET /api/posts/[id]', () => {
     const platform = { env: {}, ctx: {}, caches: {} };
     const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
     const response = await GET(event);
-    const result: ApiResponse<null> = await response.json();
+    const result: GetPostByIdApiResponse = await response.json();
 
     expect(response.status).toBe(500);
     expect(result.success).toBe(false);
@@ -93,7 +93,7 @@ describe('GET /api/posts/[id]', () => {
     });
     const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
     const response = await GET(event);
-    const result: ApiResponse<null> = await response.json();
+    const result: GetPostByIdApiResponse = await response.json();
 
     expect(response.status).toBe(404);
     expect(result.success).toBe(false);
@@ -116,7 +116,7 @@ describe('GET /api/posts/[id]', () => {
     });
     const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
     const response = await GET(event);
-    const result: ApiResponse<Post> = await response.json();
+    const result: GetPostByIdApiResponse = await response.json();
 
     expect(response.status).toBe(200);
     expect(result.success).toBe(true);
@@ -132,7 +132,7 @@ describe('GET /api/posts/[id]', () => {
     });
     const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
     const response = await GET(event);
-    const result: ApiResponse<null> = await response.json();
+    const result: GetPostByIdApiResponse = await response.json();
 
     expect(response.status).toBe(500);
     expect(result.success).toBe(false);

--- a/src/routes/api/posts/[id]/server.spec.ts
+++ b/src/routes/api/posts/[id]/server.spec.ts
@@ -1,0 +1,142 @@
+import type { RequestEvent } from '@sveltejs/kit';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApiResponse } from '$lib/types/api';
+import type { Post } from '$lib/types/post';
+
+import { GET } from './+server';
+
+type MockBucket = {
+  get?: (key: string) => Promise<{ json: <T>() => Promise<T> } | null>;
+};
+
+function createMockPlatform(bucketImpl?: MockBucket) {
+  return {
+    env: {
+      BLOG: bucketImpl,
+    },
+    ctx: {},
+    caches: {},
+  };
+}
+
+function createMockEvent({
+  request,
+  platform,
+  postId,
+}: {
+  request: Request;
+  platform?: object;
+  postId?: string;
+}): RequestEvent {
+  return {
+    request,
+    platform,
+    cookies: {
+      get: () => undefined,
+      getAll: () => [],
+      set: () => {},
+      delete: () => {},
+      serialize: () => '',
+    },
+    fetch: global.fetch,
+    getClientAddress: () => '',
+    locals: {},
+    params: { id: postId ?? '' },
+    route: { id: '/api/posts/[id]' },
+    url: new URL(request.url),
+    setHeaders: () => {},
+    isDataRequest: false,
+    isSubRequest: false,
+    tracing: { enabled: false, root: null, current: null },
+    isRemoteRequest: false,
+  } as unknown as RequestEvent;
+}
+
+const MOCK_POST_ID = crypto.randomUUID();
+
+describe('GET /api/posts/[id]', () => {
+  it('should return 400 when post id is missing', async () => {
+    const request = new Request('http://localhost/api/posts/', {
+      method: 'GET',
+    });
+    const platform = createMockPlatform();
+    const event = createMockEvent({ request, platform, postId: '' });
+    const response = await GET(event);
+    const result: ApiResponse<null> = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_REQUEST');
+  });
+
+  it('should return 500 if BLOG bucket is missing', async () => {
+    const request = new Request(`http://localhost/api/posts/${MOCK_POST_ID}`, {
+      method: 'GET',
+    });
+    const platform = { env: {}, ctx: {}, caches: {} };
+    const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
+    const response = await GET(event);
+    const result: ApiResponse<null> = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('BUCKET_NOT_FOUND');
+  });
+
+  it('should return 404 when post does not exist', async () => {
+    const mockGet = vi.fn().mockResolvedValue(null);
+    const platform = createMockPlatform({ get: mockGet });
+    const request = new Request(`http://localhost/api/posts/${MOCK_POST_ID}`, {
+      method: 'GET',
+    });
+    const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
+    const response = await GET(event);
+    const result: ApiResponse<null> = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('POST_NOT_FOUND');
+    expect(mockGet).toHaveBeenCalledWith(MOCK_POST_ID);
+  });
+
+  it('should return post when found', async () => {
+    const post: Post = {
+      id: MOCK_POST_ID,
+      title: 'title',
+      content: 'content',
+      createdAt: '2026-03-01T00:00:00.000Z',
+      updatedAt: '2026-03-01T00:00:00.000Z',
+    };
+    const mockGet = vi.fn().mockResolvedValue({ json: async () => post });
+    const platform = createMockPlatform({ get: mockGet });
+    const request = new Request(`http://localhost/api/posts/${MOCK_POST_ID}`, {
+      method: 'GET',
+    });
+    const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
+    const response = await GET(event);
+    const result: ApiResponse<Post> = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(post);
+    expect(mockGet).toHaveBeenCalledWith(MOCK_POST_ID);
+  });
+
+  it('should handle server errors', async () => {
+    const mockGet = vi.fn().mockRejectedValue(new Error('fail'));
+    const platform = createMockPlatform({ get: mockGet });
+    const request = new Request(`http://localhost/api/posts/${MOCK_POST_ID}`, {
+      method: 'GET',
+    });
+    const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
+    const response = await GET(event);
+    const result: ApiResponse<null> = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('SERVER_ERROR');
+    expect(result.error?.message).toBe('fail');
+  });
+});

--- a/src/routes/api/posts/server.spec.ts
+++ b/src/routes/api/posts/server.spec.ts
@@ -2,7 +2,10 @@ import type { RequestEvent } from '@sveltejs/kit';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { ApiResponse } from '$lib/types/api';
+import type {
+  CreatePostApiResponse,
+  ListPostsApiResponse,
+} from '$lib/types/api';
 import type { Post } from '$lib/types/post';
 
 import { GET, POST } from './+server';
@@ -76,7 +79,7 @@ describe('POST /api/posts', () => {
     const platform = createMockPlatform(mockBucket);
     const event = createMockEvent({ request, platform });
     const response = await POST(event);
-    const result: ApiResponse<null> = await response.json();
+    const result: CreatePostApiResponse = await response.json();
 
     expect(response.status).toBe(400);
     expect(result.success).toBe(false);
@@ -99,7 +102,7 @@ describe('POST /api/posts', () => {
     const platform = { env: {}, ctx: {}, caches: {} };
     const event = createMockEvent({ request, platform });
     const response = await POST(event);
-    const result: ApiResponse<null> = await response.json();
+    const result: CreatePostApiResponse = await response.json();
 
     expect(response.status).toBe(500);
     expect(result.success).toBe(false);
@@ -116,7 +119,7 @@ describe('POST /api/posts', () => {
     const platform = createMockPlatform(mockBucket);
     const event = createMockEvent({ request, platform });
     const response = await POST(event);
-    const result: ApiResponse<Post> = await response.json();
+    const result: CreatePostApiResponse = await response.json();
 
     expect(response.status).toBe(200);
     expect(result.success).toBe(true);
@@ -151,7 +154,7 @@ describe('POST /api/posts', () => {
     const platform = createMockPlatform(mockBucket);
     const event = createMockEvent({ request, platform });
     const response = await POST(event);
-    const result: ApiResponse<null> = await response.json();
+    const result: CreatePostApiResponse = await response.json();
 
     expect(response.status).toBe(500);
     expect(result.success).toBe(false);
@@ -168,7 +171,7 @@ describe('GET /api/posts', () => {
     const platform = { env: {}, ctx: {}, caches: {} };
     const event = createMockEvent({ request, platform });
     const response = await GET(event);
-    const result: ApiResponse<null> = await response.json();
+    const result: ListPostsApiResponse = await response.json();
 
     expect(response.status).toBe(500);
     expect(result.success).toBe(false);
@@ -214,7 +217,7 @@ describe('GET /api/posts', () => {
     const platform = createMockPlatform({ list: mockList, get: mockGet });
     const event = createMockEvent({ request, platform });
     const response = await GET(event);
-    const result: ApiResponse<Post[]> = await response.json();
+    const result: ListPostsApiResponse = await response.json();
 
     expect(response.status).toBe(200);
     expect(result.success).toBe(true);
@@ -235,7 +238,7 @@ describe('GET /api/posts', () => {
     const platform = createMockPlatform({ list: mockList });
     const event = createMockEvent({ request, platform });
     const response = await GET(event);
-    const result: ApiResponse<null> = await response.json();
+    const result: ListPostsApiResponse = await response.json();
 
     expect(response.status).toBe(500);
     expect(result.success).toBe(false);

--- a/src/routes/api/posts/server.spec.ts
+++ b/src/routes/api/posts/server.spec.ts
@@ -5,10 +5,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ApiResponse } from '$lib/types/api';
 import type { Post } from '$lib/types/post';
 
-import { POST } from './+server';
+import { GET, POST } from './+server';
 
 type MockBucket = {
-  put: (key: string, value: string) => void;
+  put?: (key: string, value: string) => void;
+  get?: (key: string) => Promise<{ json: <T>() => Promise<T> } | null>;
+  list?: (options?: { cursor?: string }) => Promise<{
+    objects: { key: string }[];
+    truncated: boolean;
+    cursor?: string;
+  }>;
 };
 
 function createMockPlatform(bucketImpl?: MockBucket) {
@@ -125,7 +131,6 @@ describe('POST /api/posts', () => {
   });
 
   it('should handle server errors', async () => {
-    // Use a Proxy to override request.json() to throw an error, instead of using a real Request
     const request = new Proxy(
       new Request('http://localhost/api/posts', {
         method: 'POST',
@@ -146,6 +151,90 @@ describe('POST /api/posts', () => {
     const platform = createMockPlatform(mockBucket);
     const event = createMockEvent({ request, platform });
     const response = await POST(event);
+    const result: ApiResponse<null> = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('SERVER_ERROR');
+    expect(result.error?.message).toBe('fail');
+  });
+});
+
+describe('GET /api/posts', () => {
+  it('should return 500 if BLOG bucket is missing', async () => {
+    const request = new Request('http://localhost/api/posts', {
+      method: 'GET',
+    });
+    const platform = { env: {}, ctx: {}, caches: {} };
+    const event = createMockEvent({ request, platform });
+    const response = await GET(event);
+    const result: ApiResponse<null> = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('BUCKET_NOT_FOUND');
+  });
+
+  it('should return sorted posts from multiple list pages', async () => {
+    const firstPost: Post = {
+      id: crypto.randomUUID(),
+      title: 'first',
+      content: 'content-1',
+      createdAt: '2026-03-01T00:00:00.000Z',
+      updatedAt: '2026-03-01T00:00:00.000Z',
+    };
+    const secondPost: Post = {
+      id: crypto.randomUUID(),
+      title: 'second',
+      content: 'content-2',
+      createdAt: '2026-03-02T00:00:00.000Z',
+      updatedAt: '2026-03-02T00:00:00.000Z',
+    };
+
+    const mockList = vi
+      .fn()
+      .mockResolvedValueOnce({
+        objects: [{ key: firstPost.id }],
+        truncated: true,
+        cursor: 'next-page',
+      })
+      .mockResolvedValueOnce({
+        objects: [{ key: secondPost.id }],
+        truncated: false,
+      });
+
+    const mockGet = vi
+      .fn()
+      .mockResolvedValueOnce({ json: async () => firstPost })
+      .mockResolvedValueOnce({ json: async () => secondPost });
+
+    const request = new Request('http://localhost/api/posts', {
+      method: 'GET',
+    });
+    const platform = createMockPlatform({ list: mockList, get: mockGet });
+    const event = createMockEvent({ request, platform });
+    const response = await GET(event);
+    const result: ApiResponse<Post[]> = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result.success).toBe(true);
+    expect(result.data?.map(post => post.id)).toEqual([
+      secondPost.id,
+      firstPost.id,
+    ]);
+    expect(mockList).toHaveBeenNthCalledWith(1, { cursor: undefined });
+    expect(mockList).toHaveBeenNthCalledWith(2, { cursor: 'next-page' });
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle server errors', async () => {
+    const mockList = vi.fn().mockRejectedValue(new Error('fail'));
+    const request = new Request('http://localhost/api/posts', {
+      method: 'GET',
+    });
+    const platform = createMockPlatform({ list: mockList });
+    const event = createMockEvent({ request, platform });
+    const response = await GET(event);
     const result: ApiResponse<null> = await response.json();
 
     expect(response.status).toBe(500);

--- a/src/routes/posts/+page.server.ts
+++ b/src/routes/posts/+page.server.ts
@@ -1,0 +1,15 @@
+import type { ApiResponse } from '$lib/types/api';
+import type { Post } from '$lib/types/post';
+
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ fetch }) => {
+  const res = await fetch('/api/posts');
+  const response: ApiResponse<Post[]> = await res.json();
+
+  if (!response.success) {
+    return { posts: [] as Post[], loadError: response.error.message };
+  }
+
+  return { posts: response.data };
+};

--- a/src/routes/posts/+page.server.ts
+++ b/src/routes/posts/+page.server.ts
@@ -1,11 +1,11 @@
-import type { ApiResponse } from '$lib/types/api';
+import type { ListPostsApiResponse } from '$lib/types/api';
 import type { Post } from '$lib/types/post';
 
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ fetch }) => {
   const res = await fetch('/api/posts');
-  const response: ApiResponse<Post[]> = await res.json();
+  const response: ListPostsApiResponse = await res.json();
 
   if (!response.success) {
     return { posts: [] as Post[], loadError: response.error.message };

--- a/src/routes/posts/+page.svelte
+++ b/src/routes/posts/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  function formatDate(iso: string) {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  }
+
+  function getExcerpt(markdown: string, max = 200) {
+    const text = markdown
+      .replace(/!\[.*?\]\(.*?\)/g, '')
+      .replace(/\[([^\]]+)\]\(.*?\)/g, '$1')
+      .replace(/[#*`_>~-]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    return text.length > max ? text.slice(0, max) + '…' : text;
+  }
+</script>
+
+<svelte:head>
+  <title>Posts</title>
+</svelte:head>
+
+<div class="mx-auto max-w-3xl px-4 py-12">
+  <h1 class="mb-10 text-3xl font-bold tracking-tight text-gray-900">Posts</h1>
+
+  {#if data.loadError}
+    <div class="rounded-md border border-red-200 bg-red-50 p-4">
+      <p class="text-sm text-red-700">{data.loadError}</p>
+    </div>
+  {:else if data.posts.length === 0}
+    <p class="text-gray-500">No posts yet.</p>
+  {:else}
+    <ul class="divide-y divide-gray-100">
+      {#each data.posts as post (post.id)}
+        <li class="py-8">
+          <a href={resolve(`/posts/${post.id}`)} class="group block space-y-2">
+            <div class="flex justify-between">
+              <h2
+                class="text-xl font-semibold text-gray-900 transition-colors group-hover:text-blue-600"
+              >
+                {post.title}
+              </h2>
+              <time
+                class="block text-sm text-gray-400"
+                datetime={post.createdAt}
+              >
+                {formatDate(post.createdAt)}
+              </time>
+            </div>
+            <p class="line-clamp-3 leading-relaxed text-gray-600">
+              {getExcerpt(post.content)}
+            </p>
+          </a>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>

--- a/src/routes/posts/[id]/+page.server.ts
+++ b/src/routes/posts/[id]/+page.server.ts
@@ -1,0 +1,20 @@
+import { error } from '@sveltejs/kit';
+
+import type { ApiResponse } from '$lib/types/api';
+import type { Post } from '$lib/types/post';
+
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ fetch, params }) => {
+  const res = await fetch(`/api/posts/${params.id}`);
+  const response: ApiResponse<Post> = await res.json();
+
+  if (!response.success) {
+    if (res.status === 404) {
+      error(404, 'Post not found');
+    }
+    error(500, response.error.message);
+  }
+
+  return { post: response.data };
+};

--- a/src/routes/posts/[id]/+page.server.ts
+++ b/src/routes/posts/[id]/+page.server.ts
@@ -1,13 +1,12 @@
 import { error } from '@sveltejs/kit';
 
-import type { ApiResponse } from '$lib/types/api';
-import type { Post } from '$lib/types/post';
+import type { GetPostByIdApiResponse } from '$lib/types/api';
 
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ fetch, params }) => {
   const res = await fetch(`/api/posts/${params.id}`);
-  const response: ApiResponse<Post> = await res.json();
+  const response: GetPostByIdApiResponse = await res.json();
 
   if (!response.success) {
     if (res.status === 404) {

--- a/src/routes/posts/[id]/+page.svelte
+++ b/src/routes/posts/[id]/+page.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { Editor } from '$lib/components/editor';
+
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  function formatDate(iso: string) {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  }
+</script>
+
+<svelte:head>
+  <title>{data.post.title}</title>
+</svelte:head>
+
+<div class="mx-auto max-w-3xl px-4 py-12">
+  <a
+    href={resolve('/posts')}
+    class="inline-flex items-center gap-1 text-sm text-gray-500 transition-colors hover:text-gray-900"
+  >
+    ← All posts
+  </a>
+  <article class="space-y-8 py-8">
+    <header class="space-y-2 text-center">
+      <h1 class="text-3xl font-bold tracking-tight text-gray-900">
+        {data.post.title}
+      </h1>
+      <time class="block text-sm text-gray-400" datetime={data.post.createdAt}>
+        {formatDate(data.post.createdAt)}
+      </time>
+    </header>
+    <Editor content={data.post.content} readOnly />
+  </article>
+</div>

--- a/src/routes/posts/[id]/page.server.spec.ts
+++ b/src/routes/posts/[id]/page.server.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApiResponse } from '$lib/types/api';
+import type { Post } from '$lib/types/post';
+
+import type { PageServerLoadEvent } from './$types';
+import { load } from './+page.server';
+
+vi.mock('@sveltejs/kit', () => ({
+  error: (status: number, message: string): never => {
+    throw new Error(`${status}:${message}`);
+  },
+}));
+
+const mockPost: Post = {
+  id: '123e4567-e89b-12d3-a456-426614174221',
+  title: 'Post detail',
+  content: 'content',
+  createdAt: '2026-03-03T00:00:00.000Z',
+  updatedAt: '2026-03-04T00:00:00.000Z',
+};
+
+function createMockFetch(response: ApiResponse<Post>, status = 200) {
+  return vi.fn<PageServerLoadEvent['fetch']>(
+    async () =>
+      new Response(JSON.stringify(response), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      }),
+  );
+}
+
+function createLoadEvent(
+  fetch: PageServerLoadEvent['fetch'],
+  id: string,
+): PageServerLoadEvent {
+  return {
+    cookies: {} as PageServerLoadEvent['cookies'],
+    fetch,
+    getClientAddress: () => '127.0.0.1',
+    locals: {} as PageServerLoadEvent['locals'],
+    params: { id },
+    platform: undefined,
+    request: new Request(`http://localhost/posts/${id}`),
+    route: { id: '/posts/[id]' },
+    setHeaders: vi.fn(),
+    url: new URL(`http://localhost/posts/${id}`),
+    isDataRequest: false,
+    isSubRequest: false,
+    isRemoteRequest: false,
+    parent: async () => ({}),
+    depends: vi.fn(),
+    untrack: <T>(fn: () => T) => fn(),
+    tracing: {
+      enabled: false,
+      root: {} as PageServerLoadEvent['tracing']['root'],
+      current: {} as PageServerLoadEvent['tracing']['current'],
+    },
+  };
+}
+
+async function runLoad(fetch: PageServerLoadEvent['fetch'], id: string) {
+  const result = await load(createLoadEvent(fetch, id));
+  if (!result) throw new Error('Expected load to return data');
+  return result;
+}
+
+describe('[Routes] /posts/[id] - load', () => {
+  it('should fetch post by id and return post data', async () => {
+    const mockFetch = createMockFetch({
+      success: true,
+      data: mockPost,
+      error: null,
+    });
+
+    const result = await runLoad(mockFetch, mockPost.id);
+
+    expect(mockFetch).toHaveBeenCalledWith(`/api/posts/${mockPost.id}`);
+    expect(result.post).toEqual(mockPost);
+  });
+
+  it('should throw 404 when api response is not found', async () => {
+    const mockFetch = createMockFetch(
+      {
+        success: false,
+        data: null,
+        error: { code: 'NOT_FOUND', message: 'missing', details: null },
+      },
+      404,
+    );
+
+    await expect(runLoad(mockFetch, mockPost.id)).rejects.toThrow(
+      '404:Post not found',
+    );
+  });
+
+  it('should throw 500 when api response fails with non-404 status', async () => {
+    const mockFetch = createMockFetch(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Server exploded',
+          details: null,
+        },
+      },
+      500,
+    );
+
+    await expect(runLoad(mockFetch, mockPost.id)).rejects.toThrow(
+      '500:Server exploded',
+    );
+  });
+});

--- a/src/routes/posts/[id]/page.server.spec.ts
+++ b/src/routes/posts/[id]/page.server.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ApiResponse } from '$lib/types/api';
+import type { GetPostByIdApiResponse } from '$lib/types/api';
 import type { Post } from '$lib/types/post';
 
 import type { PageServerLoadEvent } from './$types';
@@ -20,7 +20,7 @@ const mockPost: Post = {
   updatedAt: '2026-03-04T00:00:00.000Z',
 };
 
-function createMockFetch(response: ApiResponse<Post>, status = 200) {
+function createMockFetch(response: GetPostByIdApiResponse, status = 200) {
   return vi.fn<PageServerLoadEvent['fetch']>(
     async () =>
       new Response(JSON.stringify(response), {

--- a/src/routes/posts/[id]/page.svelte.spec.ts
+++ b/src/routes/posts/[id]/page.svelte.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Post } from '$lib/types/post';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+import Page from './+page.svelte';
+
+const mockPost: Post = {
+  id: '123e4567-e89b-12d3-a456-426614174220',
+  title: 'Detail Title',
+  content: 'Detail content',
+  createdAt: '2026-03-01T00:00:00.000Z',
+  updatedAt: '2026-03-02T00:00:00.000Z',
+};
+
+describe('[Routes] /posts/[id]', () => {
+  it('should render back link to posts list', async () => {
+    render(Page, { data: { post: mockPost } });
+
+    await expect
+      .element(page.getByRole('link', { name: '← All posts' }))
+      .toHaveAttribute('href', '/posts');
+  });
+
+  it('should render post title and created date', async () => {
+    render(Page, { data: { post: mockPost } });
+
+    await expect
+      .element(page.getByRole('heading', { level: 1, name: mockPost.title }))
+      .toBeInTheDocument();
+    await expect.element(page.getByRole('time')).toBeInTheDocument();
+  });
+});

--- a/src/routes/posts/page.server.spec.ts
+++ b/src/routes/posts/page.server.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ApiResponse } from '$lib/types/api';
+import type { ListPostsApiResponse } from '$lib/types/api';
 import type { Post } from '$lib/types/post';
 
 import type { PageServerLoadEvent } from './$types';
@@ -14,7 +14,7 @@ const mockPost: Post = {
   updatedAt: '2026-02-20T00:00:00.000Z',
 };
 
-function createMockFetch(response: ApiResponse<Post[]>) {
+function createMockFetch(response: ListPostsApiResponse) {
   return vi.fn<PageServerLoadEvent['fetch']>(
     async () =>
       new Response(JSON.stringify(response), {
@@ -90,8 +90,9 @@ describe('[Routes] /posts - load', () => {
       error: {
         code: 'INTERNAL_SERVER_ERROR',
         message: 'Failed to load posts',
+        details: null,
       },
-    } as ApiResponse<Post[]>);
+    });
 
     const result = await runLoad(mockFetch);
 

--- a/src/routes/posts/page.server.spec.ts
+++ b/src/routes/posts/page.server.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApiResponse } from '$lib/types/api';
+import type { Post } from '$lib/types/post';
+
+import type { PageServerLoadEvent } from './$types';
+import { load } from './+page.server';
+
+const mockPost: Post = {
+  id: '123e4567-e89b-12d3-a456-426614174210',
+  title: 'Hello World',
+  content: 'Some content',
+  createdAt: '2026-01-15T00:00:00.000Z',
+  updatedAt: '2026-02-20T00:00:00.000Z',
+};
+
+function createMockFetch(response: ApiResponse<Post[]>) {
+  return vi.fn<PageServerLoadEvent['fetch']>(
+    async () =>
+      new Response(JSON.stringify(response), {
+        headers: { 'content-type': 'application/json' },
+      }),
+  );
+}
+
+function createLoadEvent(
+  fetch: PageServerLoadEvent['fetch'],
+): PageServerLoadEvent {
+  return {
+    cookies: {} as PageServerLoadEvent['cookies'],
+    fetch,
+    getClientAddress: () => '127.0.0.1',
+    locals: {} as PageServerLoadEvent['locals'],
+    params: {} as PageServerLoadEvent['params'],
+    platform: undefined,
+    request: new Request('http://localhost/posts'),
+    route: { id: '/posts' },
+    setHeaders: vi.fn(),
+    url: new URL('http://localhost/posts'),
+    isDataRequest: false,
+    isSubRequest: false,
+    isRemoteRequest: false,
+    parent: async () => ({}),
+    depends: vi.fn(),
+    untrack: <T>(fn: () => T) => fn(),
+    tracing: {
+      enabled: false,
+      root: {} as PageServerLoadEvent['tracing']['root'],
+      current: {} as PageServerLoadEvent['tracing']['current'],
+    },
+  };
+}
+
+async function runLoad(fetch: PageServerLoadEvent['fetch']) {
+  const result = await load(createLoadEvent(fetch));
+  if (!result) throw new Error('Expected load to return data');
+  return result;
+}
+
+describe('[Routes] /posts - load', () => {
+  it('should fetch from /api/posts', async () => {
+    const mockFetch = createMockFetch({
+      success: true,
+      data: [mockPost],
+      error: null,
+    });
+
+    await runLoad(mockFetch);
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/posts');
+  });
+
+  it('should return posts on success response', async () => {
+    const mockFetch = createMockFetch({
+      success: true,
+      data: [mockPost],
+      error: null,
+    });
+
+    const result = await runLoad(mockFetch);
+
+    expect(result.posts).toEqual([mockPost]);
+    expect(result.loadError).toBeUndefined();
+  });
+
+  it('should return empty posts and loadError on failure response', async () => {
+    const mockFetch = createMockFetch({
+      success: false,
+      data: null,
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to load posts',
+      },
+    } as ApiResponse<Post[]>);
+
+    const result = await runLoad(mockFetch);
+
+    expect(result.posts).toEqual([]);
+    expect(result.loadError).toBe('Failed to load posts');
+  });
+});

--- a/src/routes/posts/page.svelte.spec.ts
+++ b/src/routes/posts/page.svelte.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Post } from '$lib/types/post';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+import Page from './+page.svelte';
+
+const mockPost: Post = {
+  id: '123e4567-e89b-12d3-a456-426614174200',
+  title: 'Hello World',
+  content: '# Heading\nHello **world** text',
+  createdAt: '2026-01-15T00:00:00.000Z',
+  updatedAt: '2026-02-20T00:00:00.000Z',
+};
+
+describe('[Routes] /posts', () => {
+  it('should render page heading', async () => {
+    render(Page, { data: { posts: [] } });
+
+    await expect
+      .element(page.getByRole('heading', { level: 1 }))
+      .toHaveTextContent('Posts');
+  });
+
+  it('should render error message when loadError exists', async () => {
+    render(Page, { data: { posts: [], loadError: 'Failed to load posts' } });
+
+    await expect
+      .element(page.getByText('Failed to load posts'))
+      .toBeInTheDocument();
+  });
+
+  it('should render empty state when there are no posts', async () => {
+    render(Page, { data: { posts: [] } });
+
+    await expect.element(page.getByText('No posts yet.')).toBeInTheDocument();
+  });
+
+  it('should render post title, link, and markdown excerpt', async () => {
+    render(Page, { data: { posts: [mockPost] } });
+
+    await expect
+      .element(page.getByRole('link', { name: /Hello World/ }))
+      .toHaveAttribute('href', `/posts/${mockPost.id}`);
+    await expect
+      .element(page.getByText('Heading Hello world text'))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole('heading', { level: 2, name: 'Hello World' }))
+      .toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 🔍 Description

> This PR adds post retrieval capabilities across the API and UI, including list and detail views for both public and admin pages.
> It also refines editor behavior for read-only rendering and aligns API/type definitions with the OpenAPI schema.

<br />

## 🗝️ Key Changes

**API**
- Added `GET /api/posts` to fetch all posts, handling bucket pagination and sorting by newest first.
- Added `GET /api/posts/{id}` to fetch a single post by id.
- Implemented consistent error responses for invalid request, not found, missing bucket, and server errors.

**Pages**
- Added `/posts` list page with server load logic, empty/error states, and markdown excerpt previews.
- Added `/posts/[id]` detail page with 404/500 handling and full post rendering.
- Added `/admin/posts` list page with post table, count, and quick links to create/view posts.

**Editor**
- Added `readOnly` support to `Editor` and Milkdown config.
- Disabled editable interactions and accessibility labeling logic in read-only mode.
- Updated editor styling to better reflect non-editable state.

**Types**
- Updated `openapi.yml` with list/get-post operations and refined nullable/error schemas.
- Regenerated/updated schema-driven types and operation aliases.
- Refactored API/post types to use schema-based definitions consistently.

**Post Creation UX Improvement**
- Updated `/admin/posts/new` submission flow to redirect to `/posts/{id}` on success.
- Cleared local draft storage after successful creation.
- Removed inline success/error result UI that is no longer used.

**Test Coverage**
- Added tests for new API handlers (`/api/posts`, `/api/posts/[id]`).
- Added tests for server load logic on `/admin/posts`, `/posts`, and `/posts/[id]`.
- Added/updated UI and editor tests for read-only behavior and page states.

<br />

## 📌 Related Issue

- #17 

<br />

## 🏷️ Type of Change

> Please check the options that are relevant to this PR.

- [x] ✨ **Feat**: A new feature
- [ ] 🐞 **Fix**: A bug fix
- [x] ♻️ **Refactor**: A code change that neither fixes a bug nor adds a feature
- [x] 🧪 **Test**: Adding or correcting tests
- [ ] 🧩 **Style**: Changes that do not affect the meaning of the code (formatting, etc.)
- [ ] 🎨 **Design**: UI/UX design changes
- [ ] 📁 **Assets**: Adding or updating asset files (images, fonts, etc.)
- [ ] 📝 **Docs**: Documentation only changes
- [ ] ⚙️ **Chore**: Build process, package manager configs, etc.

<br />

## 🔗 Reference (Optional)

### Links

- [Routing · SvelteKit Docs](https://svelte.dev/docs/kit/routing)
- [Loading data · SvelteKit Docs](https://svelte.dev/docs/kit/load)

<br />

## ✅ Checklist

- [x] My code follows the **Commit Message Convention** of this project.
- [x] I have performed a self-review of my own code.
- [x] For `🧪 Test` changes, all tests passed successfully.
- [ ] For `🧩 Style` changes, code formatting is consistent.
- [x] I have removed unnecessary logs, comments, or debug code.

<br />

## ➕ Additional Information

- `ApiSuccessResponse` / `ApiErrorResponse` shapes were unified to use explicit `null` values for `error` / `data` where applicable.
- `POST /admin/posts/new` UX now redirects directly to `/posts/{id}` after successful creation (instead of rendering an inline success state).