### PR TITLE
[Feature] Add post delete API and admin delete action

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -267,6 +267,77 @@ paths:
                       code: SERVER_ERROR
                       message: Unknown error
                       details: null
+    delete:
+      summary: Delete post by id
+      operationId: deletePostById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Post id
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Post deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiSuccessResponseEmpty'
+              example:
+                success: true
+                data: null
+                error: null
+        '400':
+          description: Invalid request (missing id)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              example:
+                success: false
+                data: null
+                error:
+                  code: INVALID_REQUEST
+                  message: Post id is required
+                  details: null
+        '404':
+          description: Post not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              example:
+                success: false
+                data: null
+                error:
+                  code: POST_NOT_FOUND
+                  message: Post not found
+                  details:
+                    id: 4e9344a8-b642-47fb-8e8b-b0f1343f77df
+        '500':
+          description: Internal server error (bucket not found or unknown server error)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+              examples:
+                bucketNotFound:
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      code: BUCKET_NOT_FOUND
+                      message: Blog bucket not found in environment variables
+                      details: null
+                serverError:
+                  value:
+                    success: false
+                    data: null
+                    error:
+                      code: SERVER_ERROR
+                      message: Unknown error
+                      details: null
 
 components:
   schemas:
@@ -376,6 +447,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Post'
+        error:
+          enum: [null]
+          nullable: true
+
+    ApiSuccessResponseEmpty:
+      type: object
+      additionalProperties: false
+      required:
+        - success
+        - data
+        - error
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          enum: [null]
+          nullable: true
         error:
           enum: [null]
           nullable: true

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -25,8 +25,10 @@ export type ListPostsApiResponse = ApiResponse<SchemaPost[]>;
 export type CreatePostApiResponse = ApiResponse<SchemaPost>;
 export type GetPostByIdApiResponse = ApiResponse<SchemaPost>;
 export type UpdatePostByIdApiResponse = ApiResponse<SchemaPost>;
+export type DeletePostByIdApiResponse = ApiResponse<null>;
 
 export type ListPostsOperation = operations['listPosts'];
 export type CreatePostOperation = operations['createPost'];
 export type GetPostByIdOperation = operations['getPostById'];
 export type UpdatePostByIdOperation = operations['updatePostById'];
+export type DeletePostByIdOperation = operations['deletePostById'];

--- a/src/lib/types/schema.d.ts
+++ b/src/lib/types/schema.d.ts
@@ -34,7 +34,8 @@ export interface paths {
     /** Update post by id */
     put: operations['updatePostById'];
     post?: never;
-    delete?: never;
+    /** Delete post by id */
+    delete: operations['deletePostById'];
     options?: never;
     head?: never;
     patch?: never;
@@ -82,6 +83,14 @@ export interface components {
       /** @enum {boolean} */
       success: true;
       data: components['schemas']['Post'][];
+      /** @enum {unknown|null} */
+      error: null;
+    };
+    ApiSuccessResponseEmpty: {
+      /** @enum {boolean} */
+      success: true;
+      /** @enum {unknown|null} */
+      data: null;
       /** @enum {unknown|null} */
       error: null;
     };
@@ -289,6 +298,87 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
+          'application/json': components['schemas']['ApiErrorResponse'];
+        };
+      };
+      /** @description Post not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example {
+           *       "success": false,
+           *       "data": null,
+           *       "error": {
+           *         "code": "POST_NOT_FOUND",
+           *         "message": "Post not found",
+           *         "details": {
+           *           "id": "4e9344a8-b642-47fb-8e8b-b0f1343f77df"
+           *         }
+           *       }
+           *     }
+           */
+          'application/json': components['schemas']['ApiErrorResponse'];
+        };
+      };
+      /** @description Internal server error (bucket not found or unknown server error) */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ApiErrorResponse'];
+        };
+      };
+    };
+  };
+  deletePostById: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Post id */
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Post deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example {
+           *       "success": true,
+           *       "data": null,
+           *       "error": null
+           *     }
+           */
+          'application/json': components['schemas']['ApiSuccessResponseEmpty'];
+        };
+      };
+      /** @description Invalid request (missing id) */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          /**
+           * @example {
+           *       "success": false,
+           *       "data": null,
+           *       "error": {
+           *         "code": "INVALID_REQUEST",
+           *         "message": "Post id is required",
+           *         "details": null
+           *       }
+           *     }
+           */
           'application/json': components['schemas']['ApiErrorResponse'];
         };
       };

--- a/src/routes/admin/posts/+page.svelte
+++ b/src/routes/admin/posts/+page.svelte
@@ -12,6 +12,33 @@
       day: 'numeric',
     });
   }
+
+  async function handleDelete(postId: string) {
+    if (
+      !confirm(
+        'Are you sure you want to delete this post? This action cannot be undone.',
+      )
+    )
+      return;
+
+    try {
+      const response = await fetch(`/api/posts/${postId}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok)
+        throw new Error(`Failed to delete post (status ${response.status})`);
+
+      data = {
+        ...data,
+        posts: data.posts.filter(post => post.id !== postId),
+      };
+    } catch (error) {
+      console.error(
+        `Error deleting post: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
 </script>
 
 <svelte:head>
@@ -96,6 +123,14 @@
                   >
                     Edit
                   </a>
+                  <button
+                    type="button"
+                    class="font-medium text-red-500 hover:text-red-700"
+                    aria-label="Delete"
+                    onclick={() => handleDelete(post.id)}
+                  >
+                    Delete
+                  </button>
                 </div>
               </td>
             </tr>

--- a/src/routes/admin/posts/page.svelte.spec.ts
+++ b/src/routes/admin/posts/page.svelte.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Post } from '$lib/types/post';
 import { render } from 'vitest-browser-svelte';
@@ -84,6 +84,17 @@ describe('[Routes] /admin/posts', () => {
   });
 
   describe('posts table', () => {
+    beforeEach(() => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(() => Promise.resolve({ ok: true, status: 200 })),
+      );
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
     it('should render table when posts exist', async () => {
       render(Page, { data: { posts: [mockPost] } });
 
@@ -129,6 +140,27 @@ describe('[Routes] /admin/posts', () => {
       await expect
         .element(page.getByRole('link', { name: 'Edit' }))
         .toBeInTheDocument();
+    });
+
+    it('should render a "Delete" button for the post', async () => {
+      render(Page, { data: { posts: [mockPost] } });
+
+      await expect
+        .element(page.getByRole('button', { name: 'Delete' }))
+        .toBeInTheDocument();
+    });
+
+    it('should remove post from table when Delete button is clicked', async () => {
+      vi.stubGlobal('confirm', () => true);
+      render(Page, { data: { posts: [mockPost] } });
+
+      await page.getByRole('button', { name: 'Delete' }).click();
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? '';
+        expect(text).not.toContain(mockPost.title);
+        expect(text).not.toContain(mockPost.id);
+      });
     });
 
     it('should not show empty state when posts exist', async () => {

--- a/src/routes/api/posts/[id]/+server.ts
+++ b/src/routes/api/posts/[id]/+server.ts
@@ -224,3 +224,83 @@ export const PUT: RequestHandler = async ({
     );
   }
 };
+
+export const DELETE: RequestHandler = async ({
+  platform,
+  params,
+}): Promise<Response> => {
+  try {
+    const postId = params.id;
+    if (!postId) {
+      const error: ApiError = {
+        code: 'INVALID_REQUEST',
+        message: 'Post id is required',
+        details: null,
+      };
+
+      return json(
+        { success: false, data: null, error } satisfies ApiErrorResponse,
+        {
+          status: 400,
+          statusText: 'Bad Request',
+        },
+      );
+    }
+
+    const bucket = platform?.env.BLOG;
+    if (!bucket) {
+      const error: ApiError = {
+        code: 'BUCKET_NOT_FOUND',
+        message: 'Blog bucket not found in environment variables',
+        details: null,
+      };
+
+      return json(
+        { success: false, data: null, error } satisfies ApiErrorResponse,
+        {
+          status: 500,
+          statusText: 'Internal Server Error',
+        },
+      );
+    }
+
+    const storedPost = await bucket.get(postId);
+    if (!storedPost) {
+      const error: ApiError = {
+        code: 'POST_NOT_FOUND',
+        message: 'Post not found',
+        details: { id: postId },
+      };
+
+      return json(
+        { success: false, data: null, error } satisfies ApiErrorResponse,
+        {
+          status: 404,
+          statusText: 'Not Found',
+        },
+      );
+    }
+
+    await bucket.delete(postId);
+
+    return json({
+      success: true,
+      data: null,
+      error: null,
+    } satisfies ApiSuccessResponse<null>);
+  } catch (e) {
+    const error: ApiError = {
+      code: 'SERVER_ERROR',
+      message: e instanceof Error ? e.message : 'Unknown error',
+      details: null,
+    };
+
+    return json(
+      { success: false, data: null, error } satisfies ApiErrorResponse,
+      {
+        status: 500,
+        statusText: 'Internal Server Error',
+      },
+    );
+  }
+};

--- a/src/routes/api/posts/[id]/server.spec.ts
+++ b/src/routes/api/posts/[id]/server.spec.ts
@@ -3,16 +3,18 @@ import type { RequestEvent } from '@sveltejs/kit';
 import { describe, expect, it, vi } from 'vitest';
 
 import type {
+  DeletePostByIdApiResponse,
   GetPostByIdApiResponse,
   UpdatePostByIdApiResponse,
 } from '$lib/types/api';
 import type { Post } from '$lib/types/post';
 
-import { GET, PUT } from './+server';
+import { DELETE, GET, PUT } from './+server';
 
 type MockBucket = {
   get?: (key: string) => Promise<{ json: <T>() => Promise<T> } | null>;
   put?: (key: string, value: string) => Promise<void>;
+  delete?: (key: string) => Promise<void>;
 };
 
 function createMockPlatform(bucketImpl?: MockBucket) {
@@ -289,5 +291,116 @@ describe('PUT /api/posts/[id]', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('SERVER_ERROR');
     expect(result.error?.message).toBe('fail');
+  });
+});
+
+describe('DELETE /api/posts/[id]', () => {
+  it('should return 400 when post id is missing', async () => {
+    const request = new Request('http://localhost/api/posts/', {
+      method: 'DELETE',
+    });
+    const platform = createMockPlatform();
+    const event = createMockEvent({ request, platform, postId: '' });
+    const response = await DELETE(event);
+    const result: DeletePostByIdApiResponse = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_REQUEST');
+  });
+
+  it('should return 500 if BLOG bucket is missing', async () => {
+    const request = new Request(`http://localhost/api/posts/${MOCK_POST_ID}`, {
+      method: 'DELETE',
+    });
+    const platform = { env: {}, ctx: {}, caches: {} };
+    const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
+    const response = await DELETE(event);
+    const result: DeletePostByIdApiResponse = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('BUCKET_NOT_FOUND');
+  });
+
+  it('should return 404 when post does not exist', async () => {
+    const mockGet = vi.fn().mockResolvedValue(null);
+    const platform = createMockPlatform({ get: mockGet });
+    const request = new Request(`http://localhost/api/posts/${MOCK_POST_ID}`, {
+      method: 'DELETE',
+    });
+    const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
+    const response = await DELETE(event);
+    const result: DeletePostByIdApiResponse = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('POST_NOT_FOUND');
+    expect(mockGet).toHaveBeenCalledWith(MOCK_POST_ID);
+  });
+
+  it('should return post when found', async () => {
+    const post: Post = {
+      id: MOCK_POST_ID,
+      title: 'title',
+      content: 'content',
+      createdAt: '2026-03-01T00:00:00.000Z',
+      updatedAt: '2026-03-01T00:00:00.000Z',
+    };
+    const mockGet = vi.fn().mockResolvedValue({ json: async () => post });
+    const mockDelete = vi.fn().mockResolvedValue(undefined);
+    const platform = createMockPlatform({ get: mockGet, delete: mockDelete });
+    const request = new Request(`http://localhost/api/posts/${MOCK_POST_ID}`, {
+      method: 'DELETE',
+    });
+    const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
+    const response = await DELETE(event);
+    const result: DeletePostByIdApiResponse = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(null);
+    expect(mockGet).toHaveBeenCalledWith(MOCK_POST_ID);
+    expect(mockDelete).toHaveBeenCalledWith(MOCK_POST_ID);
+  });
+
+  it('should handle server errors during get (existence check)', async () => {
+    const mockGet = vi.fn().mockRejectedValue(new Error('fail-get'));
+    const platform = createMockPlatform({ get: mockGet });
+    const request = new Request(`http://localhost/api/posts/${MOCK_POST_ID}`, {
+      method: 'DELETE',
+    });
+    const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
+    const response = await DELETE(event);
+    const result: DeletePostByIdApiResponse = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('SERVER_ERROR');
+    expect(result.error?.message).toBe('fail-get');
+  });
+
+  it('should handle server errors during delete (delete operation)', async () => {
+    const post: Post = {
+      id: MOCK_POST_ID,
+      title: 'title',
+      content: 'content',
+      createdAt: '2026-03-01T00:00:00.000Z',
+      updatedAt: '2026-03-01T00:00:00.000Z',
+    };
+    const mockGet = vi.fn().mockResolvedValue({ json: async () => post });
+    const mockDelete = vi.fn().mockRejectedValue(new Error('fail-delete'));
+    const platform = createMockPlatform({ get: mockGet, delete: mockDelete });
+    const request = new Request(`http://localhost/api/posts/${MOCK_POST_ID}`, {
+      method: 'DELETE',
+    });
+    const event = createMockEvent({ request, platform, postId: MOCK_POST_ID });
+    const response = await DELETE(event);
+    const result: DeletePostByIdApiResponse = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('SERVER_ERROR');
+    expect(result.error?.message).toBe('fail-delete');
   });
 });


### PR DESCRIPTION
## 🔍 Description

> This PR adds the ability for admins to delete posts, including the API endpoint and UI action. It also includes tests for the new functionality.

<br />

## 🗝️ Key Changes

**API**
- Added `DELETE /api/posts/{id}` endpoint to remove a post by ID.
- Updated OpenAPI spec and types to include delete operation and response types.

**Pages**
- Added "Delete" button to the admin posts table.
- Implemented `handleDelete()` function in the admin posts page to call the delete API and update UI.

**Types**
- Added `DeletePostByIdApiResponse` and `DeletePostByIdOperation` types.

**Tests**
- Added tests for the delete API endpoint, covering success and error cases.
- Added UI tests for the delete button and post removal in the admin posts page.

<br />

## 📌 Related Issue

- #24 

<br />

## 🏷️ Type of Change

> Please check the options that are relevant to this PR.

- [x] ✨ **Feat**: A new feature
- [ ] 🐞 **Fix**: A bug fix
- [ ] ♻️ **Refactor**: A code change that neither fixes a bug nor adds a feature
- [x] 🧪 **Test**: Adding or correcting tests
- [ ] 🧩 **Style**: Changes that do not affect the meaning of the code (formatting, etc.)
- [ ] 🎨 **Design**: UI/UX design changes
- [ ] 📁 **Assets**: Adding or updating asset files (images, fonts, etc.)
- [ ] 📝 **Docs**: Documentation only changes
- [ ] ⚙️ **Chore**: Build process, package manager configs, etc.

<br />

## ✅ Checklist

- [x] My code follows the **Commit Message Convention** of this project.
- [x] I have performed a self-review of my own code.
- [x] For `🧪 Test` changes, all tests passed successfully.
- [ ] For `🧩 Style` changes, code formatting is consistent.
- [x] I have removed unnecessary logs, comments, or debug code.