### PR TITLE
fix: Failure on Cloudflare Workers deployment with "Completion token has already been consumed"

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -21,6 +21,9 @@ jobs:
     name: Deploy to Cloudflare Workers
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: deploy-worker-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: read
     outputs:


### PR DESCRIPTION
## 🔍 Description

> Fixes a Cloudflare Workers deployment failure caused by a race condition in GitHub Actions.
When multiple pushes occur in quick succession on the same branch, the workflow-level `cancel-in-progress: true` setting would cancel an in-progress deployment while Cloudflare had already consumed the completion token for that upload session — causing the next run to fail with error code `100312`.

<br />

## 🗝️ Key Changes

**CI/CD & Workflows**

- Added a dedicated `concurrency` block to the `deploy-worker` job in `.github/workflows/deployment.yml`
- Set `cancel-in-progress: false` so active deployments are queued rather than cancelled mid-flight
- Scoped the concurrency group to `deploy-worker-${{ github.ref }}` to isolate it per branch

<br />

## 📌 Related Issue

- #36

<br />

## 🏷️ Type of Change

> Please check the options that are relevant to this PR.

- [ ] ✨ **Feat**: A new feature
- [x] 🐞 **Fix**: A bug fix
- [ ] ♻️ **Refactor**: A code change that neither fixes a bug nor adds a feature
- [ ] 🧪 **Test**: Adding or correcting tests
- [ ] 🧩 **Style**: Changes that do not affect the meaning of the code (formatting, etc.)
- [ ] 🎨 **Design**: UI/UX design changes
- [ ] 📁 **Assets**: Adding or updating asset files (images, fonts, etc.)
- [ ] 📝 **Docs**: Documentation only changes
- [x] ⚙️ **Chore**: Build process, package manager configs, etc.

<br />

## 🔗 Reference (Optional)

### Links

- [Control the concurrency of workflows and jobs - GitHub Docs](https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs)

<br />

## ✅ Checklist

- [x] My code follows the **Commit Message Convention** of this project.
- [x] I have performed a self-review of my own code.
- [ ] For `🧪 Test` changes, all tests passed successfully.
- [ ] For `🧩 Style` changes, code formatting is consistent.
- [x] I have removed unnecessary logs, comments, or debug code.

<br />

## ➕ Additional Information

- The workflow-level `cancel-in-progress: true` is intentionally preserved so that non-deployment jobs (e.g., lint, build) can still be cancelled on new pushes.
- Only the `deploy-worker` job is protected from cancellation to prevent Cloudflare API token conflicts during `wrangler versions upload`.