### PR TITLE
docs: Establish architecture and documentation foundation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Blog Documentation
+
+This directory is the source of truth for Blog project's architecture, domain rules, data foundation, API contract, and security boundaries.
+
+## Architecture
+
+- [Overview](architecture/overview.md)
+- [Content Domain](architecture/content-domain.md)
+- [Database Foundation](architecture/database-foundation.md)
+- [API Contract](architecture/api-contract.md)
+- [Security](architecture/security.md)
+
+## Architectural Decision Records
+
+- [ADR-0001: Documentation and SSoT](adr/0001-documentation-and-ssot.md)
+- [ADR-0002: Markdown Content Storage](adr/0002-markdown-content-storage.md)
+- [ADR-0003: Content Lifecycle and Soft Deletion](adr/0003-content-lifecycle-and-soft-deletion.md)
+- [ADR-0004: Database and API Foundation](adr/0004-database-and-api-foundation.md)
+- [ADR-0005: Cloudflare Access Admin Authentication](adr/0005-cloudflare-access-admin-auth.md)
+
+Architecture documents describe current rules and interfaces. ADRs explain why important choices were made and what trade-offs they introduce.

--- a/docs/adr/0001-documentation-and-ssot.md
+++ b/docs/adr/0001-documentation-and-ssot.md
@@ -11,13 +11,15 @@ Without an explicit source of truth, implementation details can diverge across s
 
 ## Decision
 
-Document required behavior before implementation. Use the following sources of truth:
+Document required behavior before implementation. Establish the following sources of truth:
 
-- Architecture documents for current system rules and interfaces.
-- ADRs for the rationale behind important architectural choices.
-- Drizzle schema and migrations for database structure.
-- Zod schemas for API request and response contracts.
-- Persisted Markdown for Content body data.
+- Architecture documents define current system behavior, boundaries, and architectural rules.
+- ADRs record the rationale, alternatives, and consequences of important architectural decisions.
+- Drizzle schema and migrations define the persisted database structure and migration history.
+- Zod schemas define the machine-readable API request and response contracts and are used for runtime validation and OpenAPI generation.
+- Persisted Markdown defines the Content body source of truth.
+
+Architecture documents describe the intended current behavior, while implementation artifacts such as the Drizzle schema, migrations, and Zod schemas are the authoritative machine-readable definitions for their respective concerns. Derived values such as summary, rendered output, and editor state are not independent sources of truth.
 
 Derived values such as summary, rendered output, and editor state are not independent sources of truth.
 

--- a/docs/adr/0001-documentation-and-ssot.md
+++ b/docs/adr/0001-documentation-and-ssot.md
@@ -1,0 +1,27 @@
+# ADR-0001: Documentation and SSoT
+
+## Status
+
+Accepted
+
+## Context
+
+The project is beginning its domain, database, API, and security work from an early scaffold.
+Without an explicit source of truth, implementation details can diverge across schema, routes, UI, and deployment configuration.
+
+## Decision
+
+Document required behavior before implementation. Use the following sources of truth:
+
+- Architecture documents for current system rules and interfaces.
+- ADRs for the rationale behind important architectural choices.
+- Drizzle schema and migrations for database structure.
+- Zod schemas for API request and response contracts.
+- Persisted Markdown for Content body data.
+
+Derived values such as summary, rendered output, and editor state are not independent sources of truth.
+
+## Consequences
+
+Design decisions are reviewable before code exists, and consumers share the same contract.
+Documentation must be updated when an architectural rule changes.

--- a/docs/adr/0002-markdown-content-storage.md
+++ b/docs/adr/0002-markdown-content-storage.md
@@ -1,0 +1,26 @@
+# ADR-0002: Markdown Content Storage
+
+## Status
+
+Accepted
+
+## Context
+
+The Content editor needs a durable representation that remains portable, readable, and suitable for server-side rendering and summary extraction. HTML and editor-specific JSON would couple persisted data to a renderer or editor model.
+
+## Decision
+
+Persist the Content body as Markdown source text. Use Milkdown as the Admin editor. Milkdown's ProseMirror state is transient; saving serializes it to Markdown. Public rendering and summary extraction use the same Markdown/Remark policy.
+
+The initial editor feature set is intentionally limited to required CommonMark/GFM, history, clipboard, listener, and code-block capabilities.
+
+## Alternatives Considered
+
+- A custom `contenteditable` editor would require implementing selection, history, clipboard behavior, and Markdown conversion.
+- HTML storage would require sanitization and couples the database to rendered markup.
+- Editor JSON storage would preserve an internal model but reduce portability and complicate rendering outside the editor.
+- A plain textarea with preview is simpler, but does not provide the desired authoring experience.
+
+## Consequences
+
+Markdown remains portable and is the Content SSoT. Milkdown introduces client-side integration and may normalize equivalent Markdown during serialization. The editor must be isolated from SSR, and the rendering/summary pipeline must remain consistent with the editor's supported Markdown.

--- a/docs/adr/0003-content-lifecycle-and-soft-deletion.md
+++ b/docs/adr/0003-content-lifecycle-and-soft-deletion.md
@@ -1,0 +1,35 @@
+# ADR-0003: Content Lifecycle and Soft Deletion
+
+## Status
+
+Accepted
+
+## Context
+
+The blog needs draft, publication, archival, and recovery without losing publication history or allowing ambiguous state changes.
+
+## Decision
+
+Use three statuses:
+
+```text
+Create
+├─> Draft ──────> Published ──────> Archived
+└─> Published ─────────────────────> Archived
+```
+
+A Content can be created either as `Draft` or directly as `Published`.
+
+`Draft → Archived`, `Published → Draft`, and `Archived → Draft` are forbidden. Deletion is independent of status and uses `deleted_at` for soft deletion. Delete preserves status, slug, and `published_at`; restore clears `deleted_at` and returns the Content to its pre-deletion status.
+
+Persist `created_at`, `published_at`, `updated_at`, and `deleted_at` as UTC ISO 8601 values. `created_at` and `published_at` are immutable timestamps set once at creation and publication. `updated_at` changes for content and lifecycle changes.
+
+## Alternatives Considered
+
+- Allowing Draft to transition directly to Archived would give an unpublished item a state intended for published history.
+- Permanent deletion would prevent recovery and lose lifecycle information.
+- Resetting deleted items to Draft would lose their prior state and publication history.
+
+## Consequences
+
+The lifecycle is explicit and recoverable. UI and API commands must reject invalid transitions, and list queries must consistently distinguish normal and trash data using `deleted_at`.

--- a/docs/adr/0004-database-and-api-foundation.md
+++ b/docs/adr/0004-database-and-api-foundation.md
@@ -1,0 +1,33 @@
+# ADR-0004: Database and API Foundation
+
+## Status
+
+Accepted
+
+## Context
+
+The project needs a stable persistence and API foundation that fits Cloudflare Workers and D1 while keeping Public and Admin concerns separate.
+
+## Decision
+
+Use Drizzle ORM with Cloudflare D1 and SQLite. Use UUIDv7 text primary keys, `snake_case` database names, and `<entity>_id` foreign keys. Generate migrations with Drizzle Kit and apply them with Wrangler.
+
+Use separate API boundaries:
+
+- Public routes use `/api/contents` and slug identifiers.
+- Admin routes use `/api/admin/contents` and UUID identifiers.
+
+Use Zod as the API contract source for runtime validation and OpenAPI generation. Use opaque cursor pagination with deterministic timestamp-plus-ID ordering. Use the common structured error response defined in the API architecture document.
+
+Use separate local, production D1 resources.
+
+## Alternatives Considered
+
+- Using a different ORM or a hand-written SQL layer would create a second schema abstraction for the selected TypeScript stack.
+- Sharing one API path for Public and Admin would make visibility and authorization depend on request context.
+- Using page/offset pagination is less stable as rows are inserted or deleted while clients paginate.
+- Maintaining a separate Preview D1 would add another persistent database and migration target without providing sufficient value, since local development already validates migrations and application behavior. Worker versions uploaded with `wrangler versions upload` are validated against the same Production D1 binding before deployment.
+
+## Consequences
+
+Schema, migration, and API contracts are explicit and testable. Deployment must manage D1 migrations independently from Worker version uploads, with bindings configured separately for local development and production.

--- a/docs/adr/0005-cloudflare-access-admin-auth.md
+++ b/docs/adr/0005-cloudflare-access-admin-auth.md
@@ -1,0 +1,32 @@
+# ADR-0005: Cloudflare Access Admin Authentication
+
+## Status
+
+Accepted
+
+## Context
+
+Admin pages and mutation APIs require a consistent authentication boundary. The project is deployed on Cloudflare Workers and should use the same policy in local-connected and Production workflows without introducing an application-managed password system.
+
+## Decision
+
+Use Cloudflare Access with GitHub as the identity provider and an email allowlist for Admin access. Protect only the following paths on both Preview and Production URLs:
+
+- `/admin`
+- `/admin/*`
+- `/api/admin`
+- `/api/admin/*`
+
+The parent and descendant paths are separate because an Access wildcard does not cover its parent path. Keep public APIs outside this Access path policy.
+
+After Access authentication, `src/hooks.server.ts` provides the common application request boundary and passes request-scoped identity information to Admin routes. Unauthenticated requests may be handled by the Access login flow before reaching the Worker. Requests that reach the application and fail its checks return JSON `401` or `403` responses for Admin APIs; UI failures follow the Access login flow.
+
+## Alternatives Considered
+
+- Application-managed sessions and passwords would duplicate identity, password and recovery responsibilities.
+- Protecting the entire Preview or Production URL would unnecessarily restrict public content.
+- Per-route authentication logic would make it easier for a new Admin route to omit the required policy.
+
+## Consequences
+
+Admin access is centralized at the edge and application boundary, with a small initial authorization model. Preview and Production must both configure Access path policies and the correct email allowlist. Local development must use an Access-compatible workflow when exercising protected routes.

--- a/docs/architecture/api-contract.md
+++ b/docs/architecture/api-contract.md
@@ -63,7 +63,7 @@ Errors use:
 
 ```json
 {
-	"errors": {
+	"error": {
 		"code": "CONTENT_NOT_FOUND",
 		"message": "Content was not found.",
 		"details": {}

--- a/docs/architecture/api-contract.md
+++ b/docs/architecture/api-contract.md
@@ -1,0 +1,74 @@
+# API Contract
+
+## Resource Boundaries
+
+Public endpoints use `slug` as the external identifier. Admin endpoints use the internal UUIDv7 `id`.
+
+### Public
+
+```text
+GET /api/contents
+GET /api/contents/:slug
+```
+
+Only Content with `status = published` and `deleted_at IS NULL` is visible.
+
+### Admin
+
+```text
+GET /api/admin/contents
+POST /api/admin/contents
+GET /api/admin/contents/trash
+GET /api/admin/contents/:id
+PATCH /api/admin/contents/:id
+DELETE /api/admin/contents/:id
+POST /api/admin/contents/:id/archive
+POST /api/admin/contents/:id/publish
+POST /api/admin/contents/:id/restore
+```
+
+The normal Admin list returns all non-deleted statuses. The trash list returns all deleted Content. `DELETE` performs soft deletion.
+
+## Commands
+
+- `publish` assigns slug and `published_at` only on the Content's first publication, whether invoked during creation or through a successful transition from draft to published.
+- `archive` transitions Published to Archived.
+- `restore` clears `deleted_at` and restores the status held before deletion.
+
+Invalid transitions return `409 Conflict` with error code `INVALID_CONTENT_STATE`.
+
+## Cursor Pagination
+
+All list endpoints use an opaque `cursor` and bounded `limit`.
+
+```json
+{
+	"items": [],
+	"nextCursor": "opaque-cursor-or-null"
+}
+```
+
+Ordering is deterministic:
+
+- Public: `published_at DESC, id DESC`.
+- Admin and Trash: `updated_at DESC, id DESC`.
+
+The ID is a tie-breaker. The cursor may encode the ordering values but must remain opaque to clients.
+
+## Contracts and Errors
+
+Zod schemas are the single source for path parameters, query parameters, request bodies, responses, and generated OpenAPI definitions.
+
+Errors use:
+
+```json
+{
+	"errors": {
+		"code": "CONTENT_NOT_FOUND",
+		"message": "Content was not found.",
+		"details": {}
+	}
+}
+```
+
+Representative codes are `VALIDATION_ERROR`, `UNAUTHORIZED`, `FORBIDDEN`, `CONTENT_NOT_FOUND`, `INVALID_CONTENT_STATE`, `SLUG_CONFLICT`, and `INTERNAL_ERROR`.

--- a/docs/architecture/content-domain.md
+++ b/docs/architecture/content-domain.md
@@ -1,0 +1,66 @@
+# Content Domain
+
+## Entity
+
+Content represents a blog article and has the following persisted fields:
+
+| Field          | Rule                                                              |
+| -------------- | ----------------------------------------------------------------- |
+| `id`           | UUIDv7 identifier                                                 |
+| `title`        | Required title text                                               |
+| `body`         | Required Markdown source text                                     |
+| `status`       | `draft`, `published`, or `archived`                               |
+| `slug`         | Nullable before first publish; immutable and unique after publish |
+| `created_at`   | Set on creation; immutable afterward; UTC ISO 8601                |
+| `published_at` | Nullable until first publish; immutable afterward; UTC ISO 8601   |
+| `updated_at`   | Updated for content and lifecycle changes; UTC ISO 8601           |
+| `deleted_at`   | Nullable soft-deletion timestamp; UTC ISO 8601                    |
+
+## Status Lifecycle
+
+Content may be created in either `draft` or `published` state and may later be archived:
+
+```text
+Create
+├─> Draft ──────> Published ──────> Archived
+└─> Published ─────────────────────> Archived
+```
+
+Allowed transitions:
+
+- `Draft -> Published`
+- `Published -> Archived`
+
+Forbidden transitions:
+
+- `Draft -> Archived`
+- `Published -> Draft`
+- `Archived -> Draft`
+
+Deletion is independent of status. A deleted item retains its status, slug, and `published_at`. Restore clears `deleted_at` and returns the item to the status it had immediately before deletion. This allows deleted Draft, Published, and Archived items to be restored correctly.
+
+## Timestamps
+
+- `published_at` is set immediately before the first successful publish and is never changed afterward.
+- `updated_at` changes when title/body changes or when publish, archive, delete, or restore changes the Content lifecycle.
+- `deleted_at` is set by soft deletion and cleared by restore.
+- All timestamps are stored and returned as UTC ISO 8601 values.
+
+## Slug
+
+Slug generation occurs immediately before the first publish. Draft title edits do not generate or reserve a final slug.
+
+The normalizer:
+
+- preserves Unicode letters and numbers.
+- converts separators to `-`.
+- preserves explicitly allowlisted symbols such as `+`.
+- removes URL delimiters such as `/`, `?`, and `#`.
+- collapses repeated separators and trims leading/trailing separators.
+- rejects or handles an empty result with an explicit publish validation error.
+
+The database enforces uniqueness. A collision receives a suffix such as `-2`. After first publish, the slug does not change when the title changes.
+
+## Summary
+
+Summary is a derived response value, not a database field. The Markdown pipeline extracts visible text, excludes code blocks and other non-display elements, and limits the result to approximately 300 characters. Public rendering and summary extraction must use the same parsing policy.

--- a/docs/architecture/database-foundation.md
+++ b/docs/architecture/database-foundation.md
@@ -1,0 +1,54 @@
+# Database Foundation
+
+## Storage
+
+Drizzle ORM targets Cloudflare D1 using SQLite dialect. Table and column names are `snake_case`. Foreign keys use the `<entity>_id` convention. Primary keys use UUIDv7 values stored as text.
+
+## Content Table
+
+| Column         | Type/rule                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------- |
+| `id`           | `TEXT` primary key (UUIDv7)                                                                       |
+| `title`        | `TEXT` NOT NULL                                                                                   |
+| `body`         | `TEXT` NOT NULL — Markdown                                                                        |
+| `status`       | `TEXT` NOT NULL — `draft`, `published`, `archived`                                                |
+| `slug`         | `TEXT` NULL — unique index                                                                        |
+| `created_at`   | `TEXT` NOT NULL — UTC ISO 8601 timestamp<br>Defaults to `(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))` |
+| `published_at` | `TEXT` NULL — UTC ISO 8601 timestamp                                                              |
+| `updated_at`   | `TEXT` NOT NULL — UTC ISO 8601 timestamp<br>Defaults to `(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))` |
+| `deleted_at`   | `TEXT` NULL — UTC ISO 8601 timestamp                                                              |
+
+## Indexing
+
+Indexes must support:
+
+- unique slug lookup;
+- Public filtering by published status and non-deleted state, ordered by `published_at DESC, id DESC`;
+- Admin filtering by non-deleted state, ordered by `updated_at DESC, id DESC`;
+- Trash filtering by deleted state, ordered by `updated_at DESC, id DESC`;
+
+The exact composite index definitions should be validated against D1 query plans during implementation.
+
+## Migrations
+
+The workflow is:
+
+1. Update the Drizzle schema.
+2. Generate a migration with Drizzle Kit.
+3. Review the generated SQL.
+4. Apply the migration to the local D1 database.
+5. Run schema and application checks locally.
+6. Apply the validated migration to Production D1 explicitly.
+
+The same ordered migration history is maintained across the local D1 database and Production D1. Local development is used to validate migrations and application behavior before changes are applied to Production D1.
+
+Worker versions do not include D1 data or migration state. Production D1 migrations are therefore managed independently from Worker version uploads and deployments.
+
+## Environment Resources
+
+| Environment | D1 resource             |
+| ----------- | ----------------------- |
+| local       | Wrangler local D1 state |
+| production  | Dedicated Production D1 |
+
+A Worker version uploaded with `wrangler versions upload` is treated as a deployment candidate for final validation. This is referred to as a Preview version in the development workflow, but it does not represent a separate Worker or D1 environment.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -44,7 +44,7 @@ The project uses a single Cloudflare Worker and a single Production D1 database.
 
 A Preview URL is the URL provided for a Worker version uploaded with `wrangler versions upload`. It is used to validate the version before it is deployed to Production and does not represent a separate Worker or D1 environment.
 
-Preview versions use the same D1 binding as Production and must not perform operations that modify production data.
+Preview versions use the same D1 binding as Production. Preview versions are validation-only and must not execute mutating operations against Production D1.
 
 D1 migrations are validated locally and applied explicitly to Production D1 as part of the production deployment process. Worker versions do not version or isolate D1 storage state.
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,65 @@
+# Architecture Overview
+
+## Purpose
+
+The Blog is a SvelteKit application deployed to Cloudflare Workers. Content is stored in Cloudflare D1 through Drizzle ORM and is exposed through separate Public and Admin API boundaries.
+
+## Technology Stack
+
+- SvelteKit 2 and Svelte 5
+- Cloudflare adapter and Workers
+- Cloudflare D1 with SQLite
+- Drizzle ORM and Drizzle Kit
+- Zod-based request/response contracts and OpenAPI generation
+- Vitest for unit tests and Playwright for end-to-end tests
+- Milkdown for Admin Markdown authoring
+
+## Runtime Boundaries
+
+```text
+Public browser/API
+        |
+        ▼
+Published Content
+
+Admin browser/API
+        |
+        ▼
+Cloudflare Access -> src/hooks.server.ts -> Admin routes
+        |
+        ▼
+  Drizzle -> D1
+```
+
+Cloudflare Access protects only these paths on both Preview and Production URLs: `/admin`, `/admin/*`, `/api/admin`, and `/api/admin/*`. Public pages and Public APIs remain accessible without Admin authentication and enforce Content visibility rules in the application. The parent and descendant paths are explicit because Access wildcards do not cover their parent path.
+
+## Environments
+
+| Environment | Worker            | Database       | Purpose                                        |
+| ----------- | ----------------- | -------------- | ---------------------------------------------- |
+| local       | Local runtime     | Local D1 state | Local development, migration checks, and tests |
+| production  | Production Worker | Production D1  | Public deployment                              |
+
+The project uses a single Cloudflare Worker and a single Production D1 database. Local development uses Wrangler's local D1 state.
+
+A Preview URL is the URL provided for a Worker version uploaded with `wrangler versions upload`. It is used to validate the version before it is deployed to Production and does not represent a separate Worker or D1 environment.
+
+Preview versions use the same D1 binding as Production and must not perform operations that modify production data.
+
+D1 migrations are validated locally and applied explicitly to Production D1 as part of the production deployment process. Worker versions do not version or isolate D1 storage state.
+
+## Request Flow
+
+1. A request reaches the SvelteKit Worker.
+2. Admin paths pass through Cloudflare Access and the server hook checks the request identity and allowlist policy.
+3. The route validates parameters and payloads using Zod schemas.
+4. The application reads or writes D1 through Drizzle.
+5. The route returns a documented response or the common API error shape.
+
+## Source of Truth
+
+- Persisted Content body: Markdown source text.
+- API contract: Zod schemas.
+- Database schema: Drizzle schema and generated migrations.
+- Admin authentication boundary: Cloudflare Access plus `src/hooks.server.ts`.
+- Architectural rationale: the ADRs in this directory.

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -1,0 +1,61 @@
+# Security Architecture
+
+## Admin Authentication
+
+Cloudflare Access is the Admin authentication boundary. GitHub is the identity provider, and an email allowlist determines which authenticated identities may use Admin features.
+
+Protection applies only to the following application paths on both Preview and Production URLs:
+
+```text
+/admin
+/admin/*
+
+/api/admin
+/api/admin/*
+```
+
+The parent and descendant paths are listed separately because an Access wildcard does not cover its parent path. The `*` wildcard is used instead of a recursive `**` pattern.
+
+Other paths on the Worker Version and production URLs are not globally protected by this policy. Public pages and APIs remain accessible and enforce Published/non-deleted visibility at the application layer.
+
+## Request Handling
+
+```text
+Request
+  -> Cloudflare Access for protected paths
+  -> src/hooks.server.ts
+  -> route-level validation and authorization
+  -> application service and D1
+```
+
+`src/hooks.server.ts` centralizes the application request boundary for requests that reach the Worker. Protected-path matching is centralized through `requiresAdminAccess()` so that the UI and API use the same effective path coverage.
+
+The protected paths are:
+
+- `/admin`
+- `/api/admin`
+
+The path predicate matches each protected path itself and any descendant path. It must not treat unrelated paths with the same prefix as protected.
+
+Unauthenticated requests may be handled by the Cloudflare Access login flow before reaching `src/hooks.server.ts`. The hook handles the application-level identity and authorization checks for requests that reach the Worker.
+
+Authentication state is request-scoped and must not be stored in mutable global state.
+
+UI authentication failures follow the Cloudflare Access login flow. Admin API requests that reach the application and fail authentication or authorization checks return JSON `401` or `403` responses rather than an HTML redirect.
+
+## Authorization Scope
+
+The initial system has one Admin role represented by the email allowlist. There are no role or permission tables until a concrete multi-user requirement exists.
+
+## API Security Errors
+
+```json
+{
+	"error": {
+		"code": "FORBIDDEN",
+		"message": "Administrator access is required"
+	}
+}
+```
+
+Use `UNAUTHORIZED` when authentication is missing or invalid and `FORBIDDEN` when an authenticated identity is not allowed to access the Admin boundary.


### PR DESCRIPTION
## 🔍 Description

> Establish the project's architecture and documentation foundation as the shared source of truth before implementation begins. This PR defines the Content domain, data and API foundation, security boundary, deployment model, and the rationale behind these decisions through architecture documents and ADRs.

<br />

## 🗝️ Key Changes

**Architecture documentation**
- Add `docs/README.md` as the documentation entry point and source-of-truth guide.
- Add architecture documents for the system overview, Content domain, database foundation, API contract, and security architecture.

**Architectural Decision Records**
- Add ADR-0001 for documentation and source-of-truth responsibilities.
- Add ADR-0002 for Markdown-based Content storage and Milkdown.
- Add ADR-0003 for Content lifecycle and soft deletion.
- Add ADR-0004 for the D1/Drizzle database and Public/Admin API foundation.
- Add ADR-0005 for Cloudflare Access-based Admin authentication.

**Environment and API policy**
- Define local and production D1 resources, with Preview represented by a Worker version rather than a separate environment or D1 database.
- Treat Preview versions as validation-only and prohibit mutating operations against Production D1.
- Define slug-based Public APIs, UUID-based Admin APIs, opaque cursor pagination, and a common structured `error` response.
- Define Cloudflare Access protection for `/admin`, `/admin/*`, `/api/admin`, and `/api/admin/*` on Preview and Production URLs.

<br />

### 🔗 Reference

- [Overview · Cloudflare D1 docs](https://developers.cloudflare.com/d1)
- [Local development · Cloudflare Workers docs](https://developers.cloudflare.com/workers/local-development)
- [Wrangler · Cloudflare Workers docs](https://developers.cloudflare.com/workers/wrangler)
- [Cloudflare Access · Cloudflare Workers docs](https://developers.cloudflare.com/workers/configuration/cloudflare-access)
- [Why Milkdown | Milkdown](https://milkdown.dev/docs/guide/why-milkdown)

<br />

### ➕ Additional Information

- This PR contains documentation and architectural decisions only; implementation will follow after the design is reviewed.
- Architecture documents describe current system behavior, boundaries, and rules, while ADRs record the rationale and trade-offs behind important decisions.
- Drizzle schema and migrations are authoritative for database structure, Zod schemas are authoritative for machine-readable API contracts, and persisted Markdown is the Content body source of truth.
- Derived values such as summary, rendered output, and editor state are not independent sources of truth.

<br />

### ✅ Checklist

- [x] My code follows the **Commit Message Convention** of this project.
- [x] I have performed a self-review of my own code.
- [ ] For `🧪 Test` changes, all tests passed successfully.
- [ ] For `🧩 Style` changes, code formatting is consistent.
- [x] I have removed unnecessary logs, comments, or debug code.
