### PR TITLE
chore: Configure GitHub Actions CI/CD and Dependabot

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,0 +1,32 @@
+name: Setup Environment
+description: Common steps to set up pnpm, Node.js, cache and install dependencies
+
+inputs:
+  pnpm-version:
+    description: pnpm version
+    required: false
+    default: '11'
+  node-version:
+    description: Node.js version
+    required: false
+    default: '24'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v6
+      with:
+        version: ${{ inputs.pnpm-version }}
+        run_install: false
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'pnpm'
+        cache-dependency-path: pnpm-lock.yaml
+
+    - name: Install Dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,99 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: monday
+      time: '02:00'
+      timezone: Asia/Seoul
+
+    open-pull-requests-limit: 2
+
+    commit-message:
+      prefix: chore
+      include: scope
+
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: 'npm'
+    directory: /
+    target-branch: main
+
+    schedule:
+      interval: weekly
+      day: monday
+      time: '03:00'
+      timezone: Asia/Seoul
+
+    open-pull-requests-limit: 5
+
+    commit-message:
+      prefix: chore
+      include: scope
+
+    ignore:
+      - dependency-name: 'typescript'
+        update-types:
+          - version-update:semver-major
+
+      - dependency-name: 'svelte'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: '@sveltejs/*'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: 'tailwindcss'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: '@tailwindcss/*'
+        update-types:
+          - version-update:semver-major
+
+      - dependency-name: 'eslint'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: '@eslint/*'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: 'prettier'
+        update-types:
+          - version-update:semver-major
+
+      - dependency-name: 'vite'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: 'wrangler'
+        update-types:
+          - version-update:semver-major
+
+      - dependency-name: 'vitest'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: '@vitest/*'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: 'playwright'
+        update-types:
+          - version-update:semver-major
+      - dependency-name: '@playwright/*'
+        update-types:
+          - version-update:semver-major
+
+    groups:
+      production-deps:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-deps:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,122 @@
+name: 🤖 Auto Merge Dependabot PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  policy-check:
+    name: Policy Check
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && !github.event.pull_request.draft
+    timeout-minutes: 5
+    outputs:
+      should_merge: ${{ steps.classify.outputs.should_merge }}
+    steps:
+      - name: Fetch Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Classify Update for Auto Merge
+        id: classify
+        shell: bash
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
+          PREVIOUS_VERSION: ${{ steps.metadata.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        run: |
+          set -euo pipefail
+
+          should_merge=false
+          reason="blocked-by-policy"
+
+          case "$DEPENDENCY_TYPE:$UPDATE_TYPE" in
+          direct:development:version-update:semver-minor|direct:development:version-update:semver-patch)
+              should_merge=true; reason="dev-minor-or-patch"
+              ;;
+            direct:production:version-update:semver-patch)
+              should_merge=true; reason="prod-patch-only"
+              ;;
+
+            *:|*:null|*:unknown)
+
+              if [[ "$DEPENDENCY_NAMES" != *","* ]] && \
+                [[ "$PREVIOUS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
+                [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                
+                IFS=. read -r oM om op <<< "$PREVIOUS_VERSION"
+                IFS=. read -r nM nm np <<< "$NEW_VERSION"
+
+                if (( nM == oM )); then
+                  if [[ "$DEPENDENCY_TYPE" == "direct:development" ]] && \
+                    (( nm > om || (nm == om && np > op) )); then
+                    should_merge=true
+                    reason="dev-null-semver-fallback"
+                  
+                  elif [[ "$DEPENDENCY_TYPE" == "direct:production" ]] && \
+                      (( nm == om && np > op )); then
+                    should_merge=true
+                    reason="prod-null-patch-fallback"
+                  else
+                    reason="null-not-safe-bump-for-$DEPENDENCY_TYPE"
+                  fi
+                else
+                  reason="null-major-bump-blocked"
+                fi
+              else
+                reason="null-invalid-or-multi-deps"
+              fi
+              ;;
+          esac
+
+          echo "should_merge=$should_merge" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+
+      - name: Log Decision
+        run: |
+          echo "### Auto-Merge Decision for #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Decision: ${{ steps.classify.outputs.should_merge }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Reason: ${{ steps.classify.outputs.reason }}" >> $GITHUB_STEP_SUMMARY
+
+  auto-merge:
+    name: Auto Merge
+    runs-on: ubuntu-latest
+    needs: policy-check
+    if: |
+      needs.policy-check.result == 'success' &&
+      needs.policy-check.outputs.should_merge == 'true' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      !github.event.pull_request.draft
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+    steps:
+      - name: Approve PR for Auto Merge
+        run: |
+          gh pr review "$PR_URL" \
+            --approve \
+            --body "🚀 Auto-approved by GitHub Actions based on SemVer policy."
+
+      - name: Enable Auto Merge
+        run: |
+          gh pr merge \
+            --auto --squash "$PR_URL" \
+            --delete-branch --subject "$PR_TITLE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: ✅ CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      !github.event.pull_request.draft
+    timeout-minutes: 5
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+
+      - name: Run Lint
+        run: pnpm lint
+
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      !github.event.pull_request.draft
+    timeout-minutes: 5
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+
+      - name: Check Types
+        run: pnpm check
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      !github.event.pull_request.draft
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Run Test
+        run: pnpm test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push' ||
+      !github.event.pull_request.draft
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+
+      - name: Run Build
+        run: pnpm build

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,238 @@
+name: 🚀 Deployment
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+      - release/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.base.ref == 'main' && 'production' || 'preview' }}
+  cancel-in-progress: true
+
+env:
+  GH_REPO: ${{ github.repository }}
+  GH_TOKEN: ${{ github.token }}
+  CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+jobs:
+  deploy-worker:
+    name: Deploy to Cloudflare Workers
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.actor != 'dependabot[bot]'
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      result: ${{ steps.deploy.outcome }}
+      environment: ${{ steps.resolve.outputs.environment }}
+      sha: ${{ steps.resolve.outputs.sha }}
+      name: ${{ steps.worker-name.outputs.result }}
+      url: ${{ steps.deployment-url.outputs.result }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+
+      - name: Build
+        run: pnpm build
+
+      - name: Resolve Deployment
+        id: resolve
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ "$BASE_REF" == "main" && "$HEAD_REF" == release/* ]]; then
+            echo "environment=production" >> "$GITHUB_OUTPUT"
+            echo "wrangler-command=deploy" >> "$GITHUB_OUTPUT"
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          elif [[ "$BASE_REF" == release/* ]]; then
+            echo "environment=preview" >> "$GITHUB_OUTPUT"
+            echo "wrangler-command=versions upload" >> "$GITHUB_OUTPUT"
+            echo "sha=${{ github.event.pull_request.merge_commit_sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error:: Unsupported deployment target"
+            exit 1
+          fi
+
+      - name: Deploy with Wrangler
+        id: deploy
+        uses: cloudflare/wrangler-action@v4
+        env:
+          WRANGLER_COMMAND: ${{ steps.resolve.outputs.wrangler-command }}
+          SHA: ${{ steps.resolve.outputs.sha }}
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ env.CF_ACCOUNT_ID }}
+          command: >-
+            ${{ env.WRANGLER_COMMAND }}
+              --tag ${{ env.SHA }}
+              ${{ env.WRANGLER_COMMAND == 'deploy' && '-y' || format('--message "{0} @ {1}"', github.event.pull_request.base.ref, env.SHA) }}
+        continue-on-error: true
+
+      - name: Get Worker Name
+        id: worker-name
+        run: echo "result=$(jq -r '.name' wrangler.jsonc)" >> "$GITHUB_OUTPUT"
+
+      - name: Get Deployment URL
+        id: deployment-url
+        env:
+          RAW_URL: ${{ steps.deploy.outputs.deployment-url }}
+        run: |
+          raw_url="${RAW_URL:-}"
+          worker_url=""
+
+          if [[ "$raw_url" =~ ^https:// ]]; then
+            worker_url="$raw_url"
+          else
+            worker_url="https://$raw_url"
+          fi
+
+          echo "result=$worker_url" >> "$GITHUB_OUTPUT"
+
+  deploy-github:
+    name: Deploy to GitHub
+    runs-on: ubuntu-latest
+    needs: deploy-worker
+    timeout-minutes: 10
+    permissions:
+      deployments: write
+    env:
+      DEPLOYMENT_ENV: ${{ needs.deploy-worker.outputs.environment }}
+    steps:
+      - name: Create Deployment
+        id: create-deployment
+        env:
+          REF: ${{ needs.deploy-worker.outputs.sha }}
+        run: |
+          DEPLOYMENT_ID=$(gh api repos/$GH_REPO/deployments \
+            --method POST \
+            --header "Accept: application/vnd.github+json" \
+            --input - \
+            -q '.id' <<EOF
+          {
+            "ref": "$REF",
+            "environment": "$DEPLOYMENT_ENV",
+            "auto_merge": false,
+            "required_contexts": []
+          }
+          EOF
+          )
+
+          echo "id=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
+
+      - name: Conclude Deployment
+        env:
+          DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.id }}
+          DEPLOYMENT_STATE: ${{ needs.deploy-worker.outputs.result == 'success' && 'success' || 'failure' }}
+          DEPLOYMENT_URL: ${{ needs.deploy-worker.outputs.url }}
+        run: |
+          gh api repos/$GH_REPO/deployments/$DEPLOYMENT_ID/statuses \
+            -F state="$DEPLOYMENT_STATE" \
+            -F environment=$DEPLOYMENT_ENV \
+            -F environment_url=$DEPLOYMENT_URL
+
+  comment-pr:
+    name: Comment on Pull Request
+    runs-on: ubuntu-latest
+    needs: deploy-worker
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment Deployment Result on PR
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_COMMIT: ${{ needs.deploy-worker.outputs.sha }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          AUTHOR_URL: ${{ github.event.pull_request.user.html_url }}
+          AVATAR_URL: ${{ github.event.pull_request.user.avatar_url }}
+          DEPLOYED: ${{ needs.deploy-worker.outputs.result == 'success' }}
+          DEPLOYMENT_ENV: ${{ needs.deploy-worker.outputs.environment }}
+          DEPLOYMENT_URL: ${{ needs.deploy-worker.outputs.url }}
+          CF_WORKER_NAME: ${{ needs.deploy-worker.outputs.name }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          PR_COMMIT_SHORT="${PR_COMMIT:0:7}"
+
+          STATUS_CELL=":x: Failed"
+          [ "$DEPLOYED" = "true" ] && STATUS_CELL=":white_check_mark: Success"
+
+          BODY="### ⚡ Deploying with Cloudflare Workers
+
+          | **Status** | ${STATUS_CELL}! |
+          | :--- | :--- |
+          | **Environment** | ${DEPLOYMENT_ENV} |"
+
+          [ -n "$PR_TITLE" ] && BODY="${BODY}
+          | **Pull Request** | [${PR_TITLE}](${PR_URL}) |"
+
+          [ -n "$PR_COMMIT" ] && BODY="${BODY}
+          | **Commit** | [\`${PR_COMMIT_SHORT}\`](https://github.com/${GH_REPO}/commit/${PR_COMMIT}) |"
+
+          [ -n "$DEPLOYMENT_URL" ] && BODY="${BODY}
+          | **URL** | ${DEPLOYMENT_URL} |"
+
+          [ -n "$AUTHOR" ] && BODY="${BODY}
+          | **Author** | <img src=\"${AVATAR_URL}\" alt=\"avatar\" width=\"16\" height=\"16\" /> [${AUTHOR}](${AUTHOR_URL}) |"
+
+          BODY="${BODY}
+          | **Details** | :arrow_right: [GitHub Actions](https://github.com/${GH_REPO}/actions/runs/${RUN_ID}) <br /> :arrow_right: [Cloudflare Dashboard](https://dash.cloudflare.com/${CF_ACCOUNT_ID}/workers/services/view/${CF_WORKER_NAME}/production/deployments) |"
+
+          gh pr comment "$PR_NUMBER" \
+            --repo "$GH_REPO" \
+            --body "$BODY"
+
+  release-github:
+    name: Release on GitHub
+    runs-on: ubuntu-latest
+    needs: deploy-worker
+    if: |
+      needs.deploy-worker.outputs.result == 'success' &&
+      needs.deploy-worker.outputs.environment == 'production'
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          sparse-checkout: package.json
+          sparse-checkout-cone-mode: false
+
+      - name: Get Current Version
+        id: package
+        run: echo "version=$(jq -r '.version' package.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Check Tag Existence
+        id: tag
+        env:
+          VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          git fetch --tags --force
+
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "⚠️ Tag v$VERSION already exists. Skipping release."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "✅ Tag v$VERSION is new. Proceeding..."
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        if: steps.tag.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          gh release create "v$VERSION" \
+            --target main \
+            --title "v$VERSION" \
+            --generate-notes


### PR DESCRIPTION
## 🔍 Description

> Configure GitHub Actions CI/CD workflows and Dependabot automation to establish a consistent validation, deployment, and dependency update process for the project.

<br />

## 🗝️ Key Changes

**GitHub Actions CI/CD**
- Add a reusable `setup-env` composite action for consistent pnpm, Node.js, dependency caching, and installation across workflows.
- Add a CI workflow for pull requests and pushes to `main`.
- Run linting, type checking, tests, and production builds as automated CI checks.
- Skip CI jobs for draft pull requests while continuing to validate pushes to `main`.
- Add concurrency controls to cancel outdated workflow

**Deployment**
- Add a deployment workflow triggered when pull requests targeting `main` or `release/**` are merged.
- Deploy `release/**` merges to Cloudflare Workers as Preview versions.
- Deploy `release/**` → `main` merges to the Production Cloudflare Worker.
- Resolve deployment metadata and expose the deployment environment, commit SHA, Worker name, and deployment URL.
- Create GitHub deployments and releases based on the resolved deployment target.
- Prevent Dependabot pull requests from triggering the deployment workflow.

**Dependabot**
- Configure weekly dependency updates for GitHub Actions and npm dependencies.
- Group minor and patch updates to reduce unnecessary pull request noise.
- Limit the number of concurrently open Dependabot pull requests.
- Block automatic major-version updates for core development and build dependencies such as TypeScript, Svelte, Tailwind CSS, ESLint, Prettier, Vite, Wrangler, Vitest, and Playwright.

**Dependabot Auto Merge**
- Add a policy-based workflow for automatically approving and merging safe Dependabot updates.
- Automatically merge development dependency minor and patch updates.
- Automatically merge production dependency patch updates.
- Add a SemVer fallback for cases where Dependabot metadata is unavailable or incomplete.
- Block major updates and unsupported or ambiguous dependency updates from automatic merging.
- Use squash merging and delete the Dependabot branch after a successful merge.

<br />

### 🔗 Reference

- [Continuous integration - GitHub Docs](https://docs.github.com/actions/get-started/continuous-integration)
- [Continuous deployment - GitHub Docs](https://docs.github.com/actions/get-started/continuous-deployment)
- [Dependabot options reference - GitHub Docs](https://docs.github.com/code-security/reference/supply-chain-security/dependabot-options-reference)
- [cloudflare/wrangler-action: 🧙‍♀️ easily deploy cloudflare workers applications using wrangler and github actions](https://github.com/cloudflare/wrangler-action)
- [Workers · Cloudflare Workers docs](https://developers.cloudflare.com/workers/wrangler/commands/workers)
- [Manual | GitHub CLI](https://cli.github.com/manual)

<br />

### ➕ Additional Information

- This PR implements the CI/CD and dependency automation.
- CI is responsible for validating linting, types, tests, and builds before changes are intergrated.
- Deployment follows the existing branch and release model: `release/**` is used for Preview deployments, while merges into `main` are deployed to Production.
- Dependabot automation intentionally destinguishes development and production dependencies to reduce the risk of automatically merging unsafe updates.
- Major-version dependency updates remain manual to allow explicit review of potentially breaking changes.
- The workflows use repository-level configuration and do not introduce application-specific behavior.
- The commits in this PR follow the project's existing `chore(scope): …` commit message convention.

<br />

### ✅ Checklist

- [x] My code follows the **Commit Message Convention** of this project.
- [x] I have performed a self-review of my own code.
- [ ] For `🧪 Test` changes, all tests passed successfully.
- [ ] For `🧩 Style` changes, code formatting is consistent.
- [x] I have removed unnecessary logs, comments, or debug code.
