### PR TITLE
fix: Correct `Deployment` workflow version handling

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -85,16 +85,13 @@ jobs:
         env:
           RAW_URL: ${{ steps.deploy.outputs.deployment-url }}
         run: |
-          raw_url="${RAW_URL:-}"
-          worker_url=""
+          WORKER_URL="${RAW_URL:-}"
 
-          if [[ "$raw_url" =~ ^https:// ]]; then
-            worker_url="$raw_url"
-          else
-            worker_url="https://$raw_url"
+          if [[ -n "$WORKER_URL" && ! "$WORKER_URL" =~ ^https:// ]]; then
+            WORKER_URL="https://$WORKER_URL"
           fi
 
-          echo "result=$worker_url" >> "$GITHUB_OUTPUT"
+          echo "result=$WORKER_URL" >> "$GITHUB_OUTPUT"
 
   deploy-github:
     name: Deploy to GitHub

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,11 +49,13 @@ jobs:
         run: |
           if [[ "$BASE_REF" == "main" && "$HEAD_REF" == release/* ]]; then
             echo "environment=production" >> "$GITHUB_OUTPUT"
-            echo "wrangler-command=deploy" >> "$GITHUB_OUTPUT"
+            echo "operation=deploy" >> "$GITHUB_OUTPUT"
+            echo "options=--version-tag" >> "$GITHUB_OUTPUT"
             echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
           elif [[ "$BASE_REF" == release/* ]]; then
             echo "environment=preview" >> "$GITHUB_OUTPUT"
-            echo "wrangler-command=versions upload" >> "$GITHUB_OUTPUT"
+            echo "operation=upload" >> "$GITHUB_OUTPUT"
+            echo "options=--tag" >> "$GITHUB_OUTPUT"
             echo "sha=${{ github.event.pull_request.merge_commit_sha }}" >> "$GITHUB_OUTPUT"
           else
             echo "::error:: Unsupported deployment target"
@@ -64,15 +66,14 @@ jobs:
         id: deploy
         uses: cloudflare/wrangler-action@v4
         env:
-          WRANGLER_COMMAND: ${{ steps.resolve.outputs.wrangler-command }}
+          OPERATION: ${{ steps.resolve.outputs.operation }}
+          OPTIONS: ${{ steps.resolve.outputs.options }}
           SHA: ${{ steps.resolve.outputs.sha }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ env.CF_ACCOUNT_ID }}
           command: >-
-            ${{ env.WRANGLER_COMMAND }}
-              --tag ${{ env.SHA }}
-              ${{ env.WRANGLER_COMMAND == 'deploy' && '-y' || format('--message "{0} @ {1}"', github.event.pull_request.base.ref, env.SHA) }}
+            versions ${{ env.OPERATION }} ${{ env.OPTIONS }} ${{ env.SHA }} ${{ env.OPERATION == 'deploy' && '-y' || format('--message "{0} @ {1}"', github.event.pull_request.base.ref, env.SHA) }}
         continue-on-error: true
 
       - name: Get Worker Name


### PR DESCRIPTION
## 🔍 Description

> Fix errors in the `Deployment` workflow by correctly handling Cloudflare Worker Version operations and empty deployment URLs.

<br />

## 🗝️ Key Changes

**Cloudflare Worker Deployment**
- Separate the Wrangler `versions` operation from its command options.
- Use `versions upload --tag` for Preview deployments.
- Use `versions deploy --version-tag` to promote the previously uploaded Version to Production.
- Use the release branch's HEAD SHA to identify the Version to deploy to Production.
- Keep the Wrangler command on a single line to ensure all arguments are passed as part of the same command.
- Automatically confirm Production Version deployments with `-y`.

**Deployment URL**
- Skip URL normalization when the deployment URL is empty.
- Preserve the empty value for the GitHub Deployment output when no deployment URL is provided.

<br />

### 🔗 Reference

- [cloudflare/wrangler-action: 🧙‍♀️ easily deploy cloudflare workers applications using wrangler and github actions](https://github.com/cloudflare/wrangler-action)
- [Workers · Cloudflare Workers docs](https://developers.cloudflare.com/workers/wrangler/commands/workers)

<br />

### ➕ Additional Information

- Preview deployments create a Worker Version with `versions upload` without promoting it to Production traffic.
- Production deployments promote the latest Version uploaded from the release branch by resolving its tag with `versions deploy --version-tag`.
- The Version tag is based on the release branch commit SHA, allowing the previously uploaded Preview Version to be promoted without creating a new Version.
- Empty deployment URLs are handled without adding an invalid `https://` prefix.

<br />

### ✅ Checklist

- [x] My code follows the **Commit Message Convention** of this project.
- [x] I have performed a self-review of my own code.
- [ ] For `🧪 Test` changes, all tests passed successfully.
- [ ] For `🧩 Style` changes, code formatting is consistent.
- [x] I have removed unnecessary logs, comments, or debug code.
