### PR TITLE
chore: Simplify pnpm commands in `test` script and Playwright configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "prettier --write .",
     "test:unit": "vitest",
     "test:coverage": "vitest --coverage",
-    "test": "pnpm run test:unit -- --run && pnpm run test:e2e",
+    "test": "pnpm test:unit -- --run && pnpm test:e2e",
     "test:e2e": "playwright install && playwright test",
     "gen": "wrangler types && prettier --write worker-configuration.d.ts",
     "db:push": "drizzle-kit push",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     video: 'retain-on-failure',
   },
   webServer: {
-    command: 'pnpm run build && pnpm run preview',
+    command: 'pnpm build && pnpm preview',
     port: 4173,
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
## 🔍 Description

> Simplify pnpm command usage in the `test` script and Playwright configuration by removing the redundant `run` keyword. This keeps the commands concise while preserving the existing test and preview behavior.

<br />

## 🗝️ Key Changes

**Simplify pnpm commands**
- Updated the `test` script in `package.json` to use `pnpm test:unit` and `pnpm test:e2e`.
- Updated the Playwright `webServer` command to use `pnpm build` and `pnpm preview`.
- No changes were made to the test or preview execution flow.

<br />

### 🔗 Reference

- N/A

<br />

### ➕ Additional Information

- This is a command syntax cleanup with no intended funtional changes.

<br />

### ✅ Checklist

- [x] My code follows the **Commit Message Convention** of this project.
- [x] I have performed a self-review of my own code.
- [ ] For `🧪 Test` changes, all tests passed successfully.
- [ ] For `🧩 Style` changes, code formatting is consistent.
- [x] I have removed unnecessary logs, comments, or debug code.
