### PR TITLE
chore: Automate release version updates

### DIFF
--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -1,0 +1,183 @@
+name: 🔖 Release Version Bump
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: true
+
+env:
+  GH_REPO: ${{ github.repository }}
+  RELEASE_REF: ${{ github.event.pull_request.head.ref }}
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-release:
+    name: Resolve Release
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'release/') &&
+      github.event.pull_request.base.ref == 'main'
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      branch: ${{ steps.release.outputs.branch }}
+    steps:
+      - name: Resolve Release Version
+        id: release
+        run: |
+          VERSION="${RELEASE_REF#release/}"
+
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error:: Invalid release branch: $RELEASE_REF"
+            echo "::error:: Expected format: release/v<major>.<minor>.<patch> "
+            exit 1
+          fi
+
+          VERSION="${VERSION#v}"
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=automation/release/v$VERSION" >> "$GITHUB_OUTPUT"
+
+  prepare-version-bump:
+    name: Prepare Version Bump
+    runs-on: ubuntu-latest
+    needs: resolve-release
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'release/') &&
+      github.event.pull_request.base.ref == 'main'
+    timeout-minutes: 10
+    env:
+      RELEASE_VERSION: ${{ needs.resolve-release.outputs.version }}
+      VERSION_BRANCH: ${{ needs.resolve-release.outputs.branch }}
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.repository }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Get GitHub App User ID
+        id: user-id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: echo "id=$(gh api "/users/$APP_SLUG[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout Code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Configure Git
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.user-id.outputs.id }}
+        run: |
+          git config --global user.name '$APP_SLUG[bot]'
+          git config --global user.email '$APP_USER_ID+$APP_SLUG[bot]@users.noreply.github.com'
+          gh auth setup-git
+
+      - name: Prepare Version Bump Branch
+        id: branch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git fetch origin "$RELEASE_REF"
+          git fetch origin "$VERSION_BRANCH" || true
+
+          git switch -C "$VERSION_BRANCH" "origin/$RELEASE_REF"
+
+          CURRENT_VERSION=$(jq -r '.version' package.json)
+
+          if [[ "$CURRENT_VERSION" == "$RELEASE_VERSION" ]]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Package version is already $CURRENT_VERSION."
+            exit 0
+          fi
+
+          jq --arg version "$RELEASE_VERSION" \
+            '.version = $version' \
+            package.json > package.json.tmp
+
+          mv package.json.tmp package.json
+
+          git add package.json
+          git commit -m "chore(release): Bump version to $RELEASE_VERSION"
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push Version Bump Branch
+        id: push
+        if: steps.branch.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: git push --force-with-lease origin "HEAD:$VERSION_BRANCH"
+
+      - name: Find or Create Version Bump PR
+        id: pr
+        if: steps.branch.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          PR_NUMBER=$(gh pr list \
+            --repo "$GH_REPO" \
+            --head "$VERSION_BRANCH" \
+            --base "$RELEASE_REF" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [[ -z "$PR_NUMBER" ]]; then
+            PR_URL=$(gh pr create \
+              --repo "$GH_REPO" \
+              --base "$RELEASE_REF" \
+              --head "$VERSION_BRANCH" \
+              --title "chore(release): Bump version to \`$RELEASE_VERSION\`" \
+              --body "$(cat <<EOF
+          ## Release Version
+
+          Bump \`package.json\` version to \`$RELEASE_VERSION\`.
+
+          This PR is automatically generated for:
+          $RELEASE_PR_URL
+
+          > The PR will be automatically merged after all required status checks pass.
+          EOF
+          )")
+
+            PR_NUMBER="${PR_URL##*/}"
+          fi
+
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Enable Auto Merge
+        if: steps.branch.outputs.changed == 'true' && steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          gh pr merge "$PR_NUMBER" \
+            --repo "$GH_REPO" \
+            --auto \
+            --squash \
+            --delete-branch \
+            --subject "chore(release): Bump version to \`$RELEASE_VERSION\`"


### PR DESCRIPTION
## 🔍 Description

> Automate release version synchronization for `release/**` branches by deriving the target version from the branch name, updating `package.json`, and merging the change back into the release branch before production promotion.

<br />

## 🗝️ Key Changes

**Release Version Bump**
- Add the `Release Version Bump` workflow for `release/**` → `main` pull requests.
- Resolve and validate the target version from the release branch name (e.g. `release/v0.1.0` → `0.1.0`).
- Create an `automation/release/v<version>` branch from the release branch and synchronize `package.json` with the target version.

**Automated Version Bump PR**
- Create the version bump commit using `chore(release): Bump version to 0.1.0`.
- Create a pull request from the automation branch back to the corresponding `release/**` branch.
- Enable squash auto-merge so the version bump is merged only after all Required Status Checks pass.
- Reuse the existing automation branch and pull request to keep the workflow idempotent and prevent duplicate pull requests.
- Skip the version update when `package.json` already contains the target release version.

**GitHub App Authentication**
- Generate a GitHub App installation token with the minumum required repository permissions.
- Use the App token for Git operations and GitHub CLI operations performed by the automation.
- Avoid using the default `GITHUB_TOKEN` identity to allow workflows triggered by generated pull request to run without manual approval.

<br />

### 🔗 Reference

- [Manual | GitHub CLI](https://cli.github.com/manual)
- [actions/create-github-app-token: GitHub Action for creating a GitHub App Installation Access Token](https://github.com/actions/create-github-app-token)

<br />

### ➕ Additional Information

- The release branch name is the source of truth for the target release version and follows `release/v<major>.<minor>.<patch>`.
- `main` is never modified directly by the version bump automation.
- The version update is intentionally merged into `release/**` before the release branch is promoted to `main`.
- The generated version bump pull request targets `release/**`, so it does not trigger the production `Deployment` workflow.
- The automation branch follows `automation/release/v<version>` and is deleted after the version bump pull request is merged.
- The existing `Deployment` workflow remains responsible for Preview/Production Worker deployment and GitHub Release creation after the release branch is merged into `main`.
- Example flow:
  ```
  release/v0.1.0 → main
        │
        ├─ Create automation/release/v0.1.0
        │    └─ package.json → 0.1.0
        │
        ├─ Create version bump PR
        │    └─ automation/release/v0.1.0 → release/v0.1.0
        │
        ├─ Required Status Checks
        │    └─ Auto-merge
        │
        └─ release/v0.1.0 → main
             ├─ Production Deployment
             └─ GitHub Release v0.1.0
  ```

<br />

### ✅ Checklist

- [x] My code follows the **Commit Message Convention** of this project.
- [x] I have performed a self-review of my own code.
- [ ] For `🧪 Test` changes, all tests passed successfully.
- [ ] For `🧩 Style` changes, code formatting is consistent.
- [x] I have removed unnecessary logs, comments, or debug code.
