### PR TITLE
fix(github/release-version-bump): Correct Git identity for version bump commits

### DIFF
--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -39,7 +39,7 @@ jobs:
 
           if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error:: Invalid release branch: $RELEASE_REF"
-            echo "::error:: Expected format: release/v<major>.<minor>.<patch> "
+            echo "::error:: Expected format: release/v<major>.<minor>.<patch>"
             exit 1
           fi
 
@@ -91,8 +91,8 @@ jobs:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
           APP_USER_ID: ${{ steps.user-id.outputs.id }}
         run: |
-          git config --global user.name '$APP_SLUG[bot]'
-          git config --global user.email '$APP_USER_ID+$APP_SLUG[bot]@users.noreply.github.com'
+          git config --global user.name "$APP_SLUG[bot]"
+          git config --global user.email "$APP_USER_ID+$APP_SLUG[bot]@users.noreply.github.com"
           gh auth setup-git
 
       - name: Prepare Version Bump Branch


### PR DESCRIPTION
## 🔍 Description

> Correct the Git identity configuration used by the automated release version bump workflow so that version bump commits are attributed to the GitHub App bot correctly.

<br />

## 🗝️ Key Changes

**GitHub App Git Identity**
- Replace single-quoted shell variables with double-quoted variables in `git config` commands.
- Ensure `APP_SLUG` and `APP_USER_ID` are expanded correctly when configuring the bot's Git name and email.
- Preserve the existing GitHub App authentication flow with `gh auth setup-git`.

**Release Branch Validation**
- Remove the trailing whitespace from the invalid release branch format error message.

<br />

### 🔗 Reference

- #12 

<br />

### ➕ Additional Information

- This fixes an issue where the generated version bump commit could contain literal shell variables such as `$APP_SLUG[bot]` instead of the resolved GitHub App identity.
- No changes are made to the release version extraction, version bump, branch, pull request, or auto-merge flow
- The GitHub App identity is now correctly resolved before creating the version bump commit.

<br />

### ✅ Checklist

- [x] My code follows the **Commit Message Convention** of this project.
- [x] I have performed a self-review of my own code.
- [ ] For `🧪 Test` changes, all tests passed successfully.
- [ ] For `🧩 Style` changes, code formatting is consistent.
- [x] I have removed unnecessary logs, comments, or debug code.
