### PR TITLE
chore(ci): Generate worker types before checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
+      - name: Generate Worker Types
+        run: pnpm gen
+
       - name: Check Types
         run: pnpm check
 
@@ -68,6 +71,9 @@ jobs:
 
       - name: Setup Environment
         uses: ./.github/actions/setup-env
+
+      - name: Generate Worker Types
+        run: pnpm gen
 
       - name: Install Playwright Browsers
         run: pnpm exec playwright install chromium --with-deps
@@ -88,6 +94,9 @@ jobs:
 
       - name: Setup Environment
         uses: ./.github/actions/setup-env
+
+      - name: Generate Worker Types
+        run: pnpm gen
 
       - name: Run Build
         run: pnpm build


### PR DESCRIPTION
## Summary

- Generate `worker-configuration.d.ts` with the installed Wrangler version before Type Check, Test, and Build jobs.
- Keep the existing `--check` validation in `pnpm check` and `pnpm build`.

## Motivation

Wrangler can update the generated Worker types when its version changes. Running `pnpm gen` before the validation steps keeps CI aligned with the installed Wrangler version instead of failing because the committed generated types are stale.