### PR TITLE
chore(github): Automate Dependabot Wrangler type synchronization

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,7 +6,11 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
+    branches:
+      - main
+
+env:
+  GH_TOKEN: ${{ github.token }}
 
 permissions:
   contents: write
@@ -20,26 +24,29 @@ jobs:
   policy-check:
     name: Policy Check
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && !github.event.pull_request.draft
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'dependabot/') &&
+      github.event.pull_request.user.login == 'dependabot[bot]' && 
+      !github.event.pull_request.draft
     timeout-minutes: 5
     outputs:
       should_merge: ${{ steps.classify.outputs.should_merge }}
     steps:
       - name: Fetch Dependabot Metadata
-        id: metadata
+        id: dependabot-metadata
         uses: dependabot/fetch-metadata@v3
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ env.GH_TOKEN }}
 
       - name: Classify Update for Auto Merge
         id: classify
         shell: bash
         env:
-          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
-          DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
-          PREVIOUS_VERSION: ${{ steps.metadata.outputs.previous-version }}
-          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
-          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          UPDATE_TYPE: ${{ steps.dependabot-metadata.outputs.update-type }}
+          DEPENDENCY_TYPE: ${{ steps.dependabot-metadata.outputs.dependency-type }}
+          PREVIOUS_VERSION: ${{ steps.dependabot-metadata.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.dependabot-metadata.outputs.new-version }}
+          DEPENDENCY_NAMES: ${{ steps.dependabot-metadata.outputs.dependency-names }}
         run: |
           set -euo pipefail
 
@@ -100,12 +107,9 @@ jobs:
     needs: policy-check
     if: |
       needs.policy-check.result == 'success' &&
-      needs.policy-check.outputs.should_merge == 'true' &&
-      github.event.pull_request.user.login == 'dependabot[bot]' &&
-      !github.event.pull_request.draft
+      needs.policy-check.outputs.should_merge == 'true'
     timeout-minutes: 5
     env:
-      GH_TOKEN: ${{ github.token }}
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
@@ -118,5 +122,7 @@ jobs:
       - name: Enable Auto Merge
         run: |
           gh pr merge \
-            --auto --squash "$PR_URL" \
-            --delete-branch --subject "$PR_TITLE"
+            --auto \
+            --squash "$PR_URL" \
+            --delete-branch \
+            --subject "$PR_TITLE"

--- a/.github/workflows/dependabot-wrangler-sync.yml
+++ b/.github/workflows/dependabot-wrangler-sync.yml
@@ -1,0 +1,127 @@
+name: 🔄 Dependabot Wrangler Types Synchronization
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  generate-wrangler-types:
+    name: Generate Wrangler Types
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'dependabot/') &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      !github.event.pull_request.draft
+    timeout-minutes: 5
+    outputs:
+      should-commit: ${{ steps.check-changes.outputs.should-commit }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+
+      - name: Fetch Dependabot Metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Generate Worker Types
+        if: |
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'wrangler') &&
+          steps.dependabot-metadata.outputs.package-ecosystem == 'npm'
+        run: pnpm gen
+
+      - name: Check for Changes in Worker Types
+        id: check-changes
+        run: |
+          if git diff --quiet -- worker-configuration.d.ts; then
+            echo "should-commit=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-commit=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload Artifact
+        if: steps.check-changes.outputs.should-commit == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: worker-types
+          path: worker-configuration.d.ts
+
+  commit-pr:
+    name: Commit Changes to PR
+    runs-on: ubuntu-latest
+    needs: generate-wrangler-types
+    if: needs.generate-wrangler-types.outputs.should-commit == 'true'
+    timeout-minutes: 5
+    env:
+      PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+    steps:
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.DEPENDABOT_WRANGLER_SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.DEPENDABOT_WRANGLER_SYNC_APP_PRIVATE_KEY }}
+          repositories: ${{ github.repository }}
+          permission-contents: write
+
+      - name: Checkout Code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.PR_HEAD_REF }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: worker-types
+          path: .
+
+      - name: Check for Changes in Worker Types
+        id: check-changes
+        run: |
+          if git diff --quiet -- worker-configuration.d.ts; then
+            echo "should-commit=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-commit=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure Git
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          gh auth setup-git
+
+      - name: Commit generated Worker Types
+        if: steps.check-changes.outputs.should-commit == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git add worker-configuration.d.ts
+          git commit -m "chore(wrangler): Update generated worker types"
+
+      - name: Push Changes to PR
+        if: steps.check-changes.outputs.should-commit == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: git push origin "HEAD:$PR_HEAD_REF"

--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -60,13 +60,12 @@ jobs:
       RELEASE_VERSION: ${{ needs.resolve-release.outputs.version }}
       VERSION_BRANCH: ${{ needs.resolve-release.outputs.branch }}
     steps:
-      - name: Generate GitHub App Token
+      - name: Create GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
           repositories: ${{ github.repository }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -64,8 +64,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          client-id: ${{ vars.RELEASE_VERSION_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_VERSION_AUTOMATION_APP_PRIVATE_KEY }}
           repositories: ${{ github.repository }}
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
## 🔍 Description

> Automate synchronization of generated Worker types for Dependabot Wrangler updates while strengthening the related Dependabot automation and standardizing GitHub App token configuration.

<br />

## 🗝️ Key Changes

**Automate Wrangler Type Synchronization**
- Add a dedicated workflow to detect Dependabot Wrangler updates.
- Run `pnpm gen` with the updated Wrangler version.
- Automatically commit generated `worker-configuration.d.ts` changes to the corresponding Dependabot PR.
- Use a dedicated GitHub App with write access limited to repository contents.

**Harden Dependabot Auto-Merge**
- Restrict the auto-merge workflow to Dependabot PRs targeting `main`.
- Standardize Dependabot metadata handling and workflow environment configuration.

**Standardize GitHub App Token Setup**
- Align GitHub App token creation across GitHub workflows.
- Use consistent naming for the GitHub App token creation step and repository configuration.

<br />

### 🔗 Reference

- [dependabot/fetch-metadata: Extract information about the dependencies being updated by a Dependabot-generated PR.](https://github.com/dependabot/fetch-metadata)
- [actions/create-github-app-token: GitHub Action for creating a GitHub App Installation Access Token](https://github.com/actions/create-github-app-token)

<br />

### ➕ Additional Information

- Wrangler updates can change the generated Worker type definitions, causing CI validation to fail when `worker-configuration.d.ts` is stale.
- Generated Worker types are synchronized only when a Dependabot PR updates Wrangler and regeneration produces changes.
- The synchronization workflow is kept separate from CI validation and Dependabot auto-merge responsibilities.
- The generated file is committed directly to the corresponding Dependabot PR so subsequent CI runs validate the synchronized state.

<br />

### ✅ Checklist

- [x] My code follows the **Commit Message Convention** of this project.
- [x] I have performed a self-review of my own code.
- [ ] For `🧪 Test` changes, all tests passed successfully.
- [ ] For `🧩 Style` changes, code formatting is consistent.
- [x] I have removed unnecessary logs, comments, or debug code.
