### PR TITLE
chore(github): Improve workflow naming and conventions

### DIFF
--- a/.github/workflows/auto-merge-dependabot-pr.yml
+++ b/.github/workflows/auto-merge-dependabot-pr.yml
@@ -30,7 +30,7 @@ jobs:
       !github.event.pull_request.draft
     timeout-minutes: 5
     outputs:
-      should_merge: ${{ steps.classify.outputs.should_merge }}
+      should-merge: ${{ steps.classify.outputs.should-merge }}
     steps:
       - name: Fetch Dependabot Metadata
         id: dependabot-metadata
@@ -50,15 +50,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          should_merge=false
+          SHOULD_MERGE=false
           reason="blocked-by-policy"
 
           case "$DEPENDENCY_TYPE:$UPDATE_TYPE" in
           direct:development:version-update:semver-minor|direct:development:version-update:semver-patch)
-              should_merge=true; reason="dev-minor-or-patch"
+              SHOULD_MERGE=true; reason="dev-minor-or-patch"
               ;;
             direct:production:version-update:semver-patch)
-              should_merge=true; reason="prod-patch-only"
+              SHOULD_MERGE=true; reason="prod-patch-only"
               ;;
 
             *:|*:null|*:unknown)
@@ -73,12 +73,12 @@ jobs:
                 if (( nM == oM )); then
                   if [[ "$DEPENDENCY_TYPE" == "direct:development" ]] && \
                     (( nm > om || (nm == om && np > op) )); then
-                    should_merge=true
+                    SHOULD_MERGE=true
                     reason="dev-null-semver-fallback"
                   
                   elif [[ "$DEPENDENCY_TYPE" == "direct:production" ]] && \
                       (( nm == om && np > op )); then
-                    should_merge=true
+                    SHOULD_MERGE=true
                     reason="prod-null-patch-fallback"
                   else
                     reason="null-not-safe-bump-for-$DEPENDENCY_TYPE"
@@ -92,13 +92,13 @@ jobs:
               ;;
           esac
 
-          echo "should_merge=$should_merge" >> "$GITHUB_OUTPUT"
+          echo "should-merge=$SHOULD_MERGE" >> "$GITHUB_OUTPUT"
           echo "reason=$reason" >> "$GITHUB_OUTPUT"
 
       - name: Log Decision
         run: |
           echo "### Auto-Merge Decision for #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Decision: ${{ steps.classify.outputs.should_merge }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Decision: ${{ steps.classify.outputs.should-merge }}" >> $GITHUB_STEP_SUMMARY
           echo "- Reason: ${{ steps.classify.outputs.reason }}" >> $GITHUB_STEP_SUMMARY
 
   auto-merge:
@@ -107,7 +107,7 @@ jobs:
     needs: policy-check
     if: |
       needs.policy-check.result == 'success' &&
-      needs.policy-check.outputs.should_merge == 'true'
+      needs.policy-check.outputs.should-merge == 'true'
     timeout-minutes: 5
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/auto-merge-dependabot-pr.yml
+++ b/.github/workflows/auto-merge-dependabot-pr.yml
@@ -51,14 +51,14 @@ jobs:
           set -euo pipefail
 
           SHOULD_MERGE=false
-          reason="blocked-by-policy"
+          REASON="blocked-by-policy"
 
           case "$DEPENDENCY_TYPE:$UPDATE_TYPE" in
           direct:development:version-update:semver-minor|direct:development:version-update:semver-patch)
-              SHOULD_MERGE=true; reason="dev-minor-or-patch"
+              SHOULD_MERGE=true; REASON="dev-minor-or-patch"
               ;;
             direct:production:version-update:semver-patch)
-              SHOULD_MERGE=true; reason="prod-patch-only"
+              SHOULD_MERGE=true; REASON="prod-patch-only"
               ;;
 
             *:|*:null|*:unknown)
@@ -74,26 +74,26 @@ jobs:
                   if [[ "$DEPENDENCY_TYPE" == "direct:development" ]] && \
                     (( nm > om || (nm == om && np > op) )); then
                     SHOULD_MERGE=true
-                    reason="dev-null-semver-fallback"
+                    REASON="dev-null-semver-fallback"
                   
                   elif [[ "$DEPENDENCY_TYPE" == "direct:production" ]] && \
                       (( nm == om && np > op )); then
                     SHOULD_MERGE=true
-                    reason="prod-null-patch-fallback"
+                    REASON="prod-null-patch-fallback"
                   else
-                    reason="null-not-safe-bump-for-$DEPENDENCY_TYPE"
+                    REASON="null-not-safe-bump-for-$DEPENDENCY_TYPE"
                   fi
                 else
-                  reason="null-major-bump-blocked"
+                  REASON="null-major-bump-blocked"
                 fi
               else
-                reason="null-invalid-or-multi-deps"
+                REASON="null-invalid-or-multi-deps"
               fi
               ;;
           esac
 
           echo "should-merge=$SHOULD_MERGE" >> "$GITHUB_OUTPUT"
-          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          echo "reason=$REASON" >> "$GITHUB_OUTPUT"
 
       - name: Log Decision
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -62,8 +62,8 @@ jobs:
         if: steps.resolve.outputs.environment == 'preview'
         run: pnpm build
 
-      - name: Deploy Worker Version
-        id: deploy-version
+      - name: Publish Worker Version
+        id: publish-version
         uses: cloudflare/wrangler-action@v4
         env:
           OPERATION: ${{ steps.resolve.outputs.operation }}
@@ -88,7 +88,7 @@ jobs:
       - name: Resolve Deployment Result
         id: resolve-result
         env:
-          VERSION_RESULT: ${{ steps.deploy-version.outcome }}
+          VERSION_RESULT: ${{ steps.publish-version.outcome }}
           TRIGGER_RESULT: ${{ steps.deploy-triggers.outcome }}
           ENVIRONMENT: ${{ steps.resolve.outputs.environment }}
         run: |
@@ -103,7 +103,7 @@ jobs:
         id: deployment-metadata
         env:
           ENVIRONMENT: ${{ steps.resolve.outputs.environment }}
-          RAW_URL: ${{ steps.deploy-version.outputs.deployment-url }}
+          RAW_URL: ${{ steps.publish-version.outputs.deployment-url }}
         run: |
           WORKER_NAME=$(jq -r '.name' wrangler.jsonc)
 

--- a/.github/workflows/release-version-bump.yml
+++ b/.github/workflows/release-version-bump.yml
@@ -21,8 +21,8 @@ permissions:
   contents: read
 
 jobs:
-  resolve-release:
-    name: Resolve Release
+  resolve-release-version:
+    name: Resolve Release Version
     runs-on: ubuntu-latest
     if: |
       startsWith(github.event.pull_request.head.ref, 'release/') &&
@@ -51,14 +51,14 @@ jobs:
   prepare-version-bump:
     name: Prepare Version Bump
     runs-on: ubuntu-latest
-    needs: resolve-release
+    needs: resolve-release-version
     if: |
       startsWith(github.event.pull_request.head.ref, 'release/') &&
       github.event.pull_request.base.ref == 'main'
     timeout-minutes: 10
     env:
-      RELEASE_VERSION: ${{ needs.resolve-release.outputs.version }}
-      VERSION_BRANCH: ${{ needs.resolve-release.outputs.branch }}
+      RELEASE_VERSION: ${{ needs.resolve-release-version.outputs.version }}
+      VERSION_BRANCH: ${{ needs.resolve-release-version.outputs.branch }}
     steps:
       - name: Create GitHub App Token
         id: app-token


### PR DESCRIPTION
## 🔍 Description

> Improve naming consistency across GitHub Actions workflows by clarifying step identifiers, output names, and release version resolution jobs without changing the existing workflow behavior.

<br />

## 🗝️ Key Changes

**Standardize Dependabot Auto-Merge Naming**
- Use hyphenated output names for the auto-merge decision.
- Use uppercase shell variables for the `SHOULD_MERGE` state.
- Update all references to the renamed output consistently.

**Clarify Deployment Step Naming**
- Rename the Worker version deployment step to `Publish Worker Version`.
- Rename the corresponding step ID from `deploy-version` to `publish-version`.
- Update deployment result and metadata references to use the renamed step.

**Clarify Release Version Resolution**
- Rename the `resolve-release` job to `resolve-release-version`.
- Update dependent job references to use the new job ID.
- Make the job name explicitly describe its responsibility for resolving the release version.

<br />

### 🔗 Reference

- #15 
- #17 
- #21 

<br />

### ➕ Additional Information

- No changes are made to the existing deployment, release, or Dependabot auto-merge behavior.
- The changes are limited to naming and identifier consistency within GitHub Actions workflows.
- Existing workflow dependencies and data flow remain unchanged.

<br />

### ✅ Checklist

- [x] My code follows the **Commit Message Convention** of this project.
- [x] I have performed a self-review of my own code.
- [ ] For `🧪 Test` changes, all tests passed successfully.
- [ ] For `🧩 Style` changes, code formatting is consistent.
- [x] I have removed unnecessary logs, comments, or debug code.
