### PR TITLE
fix(github/deployment): Build before deploying triggers

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -59,7 +59,6 @@ jobs:
           fi
 
       - name: Build
-        if: steps.resolve.outputs.environment == 'preview'
         run: pnpm build
 
       - name: Publish Worker Version


### PR DESCRIPTION
## 🔍 Description

> Ensure the deployment workflow generates the build output required by `triggers deploy` in the production environment.

<br />

## 🗝️ Key Changes

**Build for all deployment environments**
- Run the build step for both Preview and Production deployments.

<br />

### 🔗 Reference

- [#triggers deploy · Commands - Wrangler · Cloudflare Workers docs](https://developers.cloudflare.com/workers/wrangler/commands/#triggers-deploy)

<br />

### ➕ Additional Information

- `triggers deploy` requires the directory configured in `assets.directory` to exist.

<br />

### ✅ Checklist

- [x] My code follows the **Commit Message Convention** of this project.
- [x] I have performed a self-review of my own code.
- [ ] For `🧪 Test` changes, all tests passed successfully.
- [ ] For `🧩 Style` changes, code formatting is consistent.
- [x] I have removed unnecessary logs, comments, or debug code.
